### PR TITLE
Dispatch guard

### DIFF
--- a/substrate/frame/system/src/mock.rs
+++ b/substrate/frame/system/src/mock.rs
@@ -96,7 +96,7 @@ impl Config for Test {
 	type OnKilledAccount = RecordKilled;
 	type MultiBlockMigrator = MockedMigrator;
 	type Nonce = TypeWithDefault<u64, DefaultNonceProvider>;
-	type DispatchGuard = (MockDispatchGuardFirst, MockDispatchGuardSecond, MockDispatchGuardThird);
+	type DispatchGuard = (DispatchGuard1, DispatchGuard2, DispatchGuard3);
 }
 
 parameter_types! {
@@ -104,48 +104,48 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub static DispatchGuardShouldFail: bool = false;
-	pub static DispatchGuardStorageWrite: bool = false;
-	pub static SecondGuardShouldFail: bool = false;
-	pub static ThirdGuardShouldFail: bool = false;
+	pub static DispatchGuard1ShouldFail: bool = false;
+	pub static DispatchGuard1StorageWrite: bool = false;
+	pub static DispatchGuard2ShouldFail: bool = false;
+	pub static DispatchGuard3ShouldFail: bool = false;
 }
 
-pub struct MockDispatchGuardFirst;
-impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for MockDispatchGuardFirst {
+pub struct DispatchGuard1;
+impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for DispatchGuard1 {
 	fn check(
 		_origin: &<Test as Config>::RuntimeOrigin,
 		_call: &<Test as Config>::RuntimeCall,
 	) -> frame_support::dispatch::DispatchResultWithPostInfo {
-		if DispatchGuardStorageWrite::get() {
+		if DispatchGuard1StorageWrite::get() {
 			frame_support::storage::unhashed::put_raw(b"dispatch_guard_write", b"written");
 		}
-		if DispatchGuardShouldFail::get() {
+		if DispatchGuard1ShouldFail::get() {
 			return Err(sp_runtime::DispatchError::Other("first guard rejected").into());
 		}
 		Ok(().into())
 	}
 }
 
-pub struct MockDispatchGuardSecond;
-impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for MockDispatchGuardSecond {
+pub struct DispatchGuard2;
+impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for DispatchGuard2 {
 	fn check(
 		_origin: &<Test as Config>::RuntimeOrigin,
 		_call: &<Test as Config>::RuntimeCall,
 	) -> frame_support::dispatch::DispatchResultWithPostInfo {
-		if SecondGuardShouldFail::get() {
+		if DispatchGuard2ShouldFail::get() {
 			return Err(sp_runtime::DispatchError::Other("second guard rejected").into());
 		}
 		Ok(().into())
 	}
 }
 
-pub struct MockDispatchGuardThird;
-impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for MockDispatchGuardThird {
+pub struct DispatchGuard3;
+impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for DispatchGuard3 {
 	fn check(
 		_origin: &<Test as Config>::RuntimeOrigin,
 		_call: &<Test as Config>::RuntimeCall,
 	) -> frame_support::dispatch::DispatchResultWithPostInfo {
-		if ThirdGuardShouldFail::get() {
+		if DispatchGuard3ShouldFail::get() {
 			return Err(sp_runtime::DispatchError::Other("third guard rejected").into());
 		}
 		Ok(().into())

--- a/substrate/frame/system/src/tests.rs
+++ b/substrate/frame/system/src/tests.rs
@@ -969,9 +969,9 @@ fn reclaim_works() {
 fn dispatch_guard_root_bypasses() {
 	new_test_ext().execute_with(|| {
 		// Root should always bypass the dispatch guard, even if all guards would reject.
-		mock::DispatchGuardShouldFail::set(true);
-		mock::SecondGuardShouldFail::set(true);
-		mock::ThirdGuardShouldFail::set(true);
+		mock::DispatchGuard1ShouldFail::set(true);
+		mock::DispatchGuard2ShouldFail::set(true);
+		mock::DispatchGuard3ShouldFail::set(true);
 		let origin = RuntimeOrigin::root();
 		assert_ok!(System::check_dispatch_guard(&origin, CALL));
 	});
@@ -988,7 +988,7 @@ fn dispatch_guard_signed_passes_when_all_guards_allow() {
 #[test]
 fn dispatch_guard_signed_fails_when_first_guard_rejects() {
 	new_test_ext().execute_with(|| {
-		mock::DispatchGuardShouldFail::set(true);
+		mock::DispatchGuard1ShouldFail::set(true);
 		let origin = RuntimeOrigin::signed(1);
 		assert_noop!(
 			System::check_dispatch_guard(&origin, CALL),
@@ -1000,7 +1000,7 @@ fn dispatch_guard_signed_fails_when_first_guard_rejects() {
 #[test]
 fn dispatch_guard_none_origin_fails_when_guard_rejects() {
 	new_test_ext().execute_with(|| {
-		mock::DispatchGuardShouldFail::set(true);
+		mock::DispatchGuard1ShouldFail::set(true);
 		let origin = RuntimeOrigin::none();
 		assert_noop!(
 			System::check_dispatch_guard(&origin, CALL),
@@ -1013,7 +1013,7 @@ fn dispatch_guard_none_origin_fails_when_guard_rejects() {
 fn dispatch_guard_rolls_back_storage_writes() {
 	new_test_ext().execute_with(|| {
 		// Enable storage writes inside the first guard.
-		mock::DispatchGuardStorageWrite::set(true);
+		mock::DispatchGuard1StorageWrite::set(true);
 
 		let origin = RuntimeOrigin::signed(1);
 		assert_ok!(System::check_dispatch_guard(&origin, CALL));
@@ -1027,8 +1027,8 @@ fn dispatch_guard_rolls_back_storage_writes() {
 fn dispatch_guard_rolls_back_storage_writes_on_failure() {
 	new_test_ext().execute_with(|| {
 		// Enable storage writes and make the guard fail.
-		mock::DispatchGuardStorageWrite::set(true);
-		mock::DispatchGuardShouldFail::set(true);
+		mock::DispatchGuard1StorageWrite::set(true);
+		mock::DispatchGuard1ShouldFail::set(true);
 
 		let origin = RuntimeOrigin::signed(1);
 		assert_noop!(
@@ -1045,7 +1045,7 @@ fn dispatch_guard_rolls_back_storage_writes_on_failure() {
 fn dispatch_guard_tuple_second_guard_rejects() {
 	new_test_ext().execute_with(|| {
 		// First guard passes, second rejects — should surface the second guard's error.
-		mock::SecondGuardShouldFail::set(true);
+		mock::DispatchGuard2ShouldFail::set(true);
 		let origin = RuntimeOrigin::signed(1);
 		assert_noop!(
 			System::check_dispatch_guard(&origin, CALL),
@@ -1058,7 +1058,7 @@ fn dispatch_guard_tuple_second_guard_rejects() {
 fn dispatch_guard_tuple_third_guard_rejects() {
 	new_test_ext().execute_with(|| {
 		// First two guards pass, third rejects.
-		mock::ThirdGuardShouldFail::set(true);
+		mock::DispatchGuard3ShouldFail::set(true);
 		let origin = RuntimeOrigin::signed(1);
 		assert_noop!(
 			System::check_dispatch_guard(&origin, CALL),
@@ -1072,9 +1072,9 @@ fn dispatch_guard_tuple_first_guard_short_circuits() {
 	new_test_ext().execute_with(|| {
 		// All three guards would reject, but the first one should short-circuit
 		// and we should see its error, not the others.
-		mock::DispatchGuardShouldFail::set(true);
-		mock::SecondGuardShouldFail::set(true);
-		mock::ThirdGuardShouldFail::set(true);
+		mock::DispatchGuard1ShouldFail::set(true);
+		mock::DispatchGuard2ShouldFail::set(true);
+		mock::DispatchGuard3ShouldFail::set(true);
 		let origin = RuntimeOrigin::signed(1);
 		assert_noop!(
 			System::check_dispatch_guard(&origin, CALL),


### PR DESCRIPTION
## Add `DispatchGuard` trait to `frame_system`

### Summary

Introduces a `DispatchGuard` mechanism that runs right before every call dispatch, providing a hook to inspect and reject calls based on origin and call data. This addresses a gap where transaction extensions only validate the top-level signed extrinsic but not inner calls (e.g. calls dispatched through `utility::batch`, `proxy::proxy`, or EVM precompiles), which can lead to bypasses for things like rate limiting.

### Changes

- **New `DispatchGuard` trait** (`frame_support::dispatch`): A simple trait with a single `check(origin, call)` method. Composable via tuples (up to 30 guards) using `impl_for_tuples`, where guards are checked sequentially and short-circuit on the first error.

- **Integrated into `frame_system::Config`**: Added as `type DispatchGuard` with `#[pallet::no_default_bounds]`. Defaults to `()` (no-op) in `TestDefaultConfig` and `SolochainDefaultConfig`, so existing runtimes are unaffected.

- **Called from `construct_runtime!`**: The generated `Dispatchable::dispatch` impl now calls `frame_system::Pallet::check_dispatch_guard()` after `BaseCallFilter` and before `dispatch_bypass_filter`. This means every dispatched call goes through the guard, including nested calls.

- **Read-only execution**: The guard runs inside `with_transaction` + `TransactionOutcome::Rollback`, so it can read storage but any writes are automatically rolled back. Root origin bypasses the guard entirely.

- **Tests**: 9 tests covering root bypass, signed/unsigned origins, guard rejection, storage write rollback, tuple composition, and short-circuit behavior.

#### Tests passing screenshot waiting for the next upgrade where the CI will finally be repaired:
<img width="1274" height="260" alt="Screenshot 2026-02-24 at 7 22 20 PM" src="https://github.com/user-attachments/assets/b22dfe65-b34f-4bcf-b5fb-a14e6fcbabf9" />
