### PR TITLE
DispatchGuard addition to frame_system

### DIFF
--- a/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -178,6 +178,8 @@ pub fn expand_outer_dispatch(
 					);
 				}
 
+				#system_path::Pallet::<#runtime>::check_dispatch_guard(&origin, &self)?;
+
 				#scrate::traits::UnfilteredDispatchable::dispatch_bypass_filter(self, origin)
 			}
 		}

--- a/substrate/frame/support/src/dispatch.rs
+++ b/substrate/frame/support/src/dispatch.rs
@@ -705,6 +705,22 @@ impl<T> PaysFee<T> for (u64, Pays) {
 
 // END TODO
 
+/// A `DispatchGuard` is executed right before the `Call` is dispatched. It has access
+/// to read-only storage and any changes will be rolled back. Root origin will passthrough.
+/// 
+/// The trait is implemented for all tuples of up to 30 elements.
+pub trait DispatchGuard<Call: Dispatchable> {
+	fn check(origin: &Call::RuntimeOrigin, call: &Call) -> DispatchResultWithPostInfo;
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+impl<Call: Dispatchable> DispatchGuard<Call> for Tuple {
+	fn check(origin: &Call::RuntimeOrigin, call: &Call) -> DispatchResultWithPostInfo {
+		for_tuples!( #( Tuple::check(origin, call)?; )* );
+		Ok(().into())
+	}
+}
+
 #[cfg(test)]
 // Do not complain about unused `dispatch` and `dispatch_aux`.
 #[allow(dead_code)]

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -127,16 +127,16 @@ use codec::{Decode, DecodeWithMemTracking, Encode, EncodeLike, FullCodec, MaxEnc
 use frame_support::traits::BuildGenesisConfig;
 use frame_support::{
 	dispatch::{
-		extract_actual_pays_fee, extract_actual_weight, DispatchClass, DispatchInfo,
+		extract_actual_pays_fee, extract_actual_weight, DispatchClass, DispatchGuard, DispatchInfo,
 		DispatchResult, DispatchResultWithPostInfo, GetDispatchInfo, PerDispatchClass,
 		PostDispatchInfo,
 	},
 	ensure, impl_ensure_origin_with_arg_ignoring_arg,
 	migrations::MultiStepMigrator,
 	pallet_prelude::Pays,
-	storage::{self, StorageStreamIter},
+	storage::{self, transactional::with_transaction, StorageStreamIter, TransactionOutcome},
 	traits::{
-		ConstU32, Contains, EnsureOrigin, EnsureOriginWithArg, Get, HandleLifetime,
+		CallerTrait, ConstU32, Contains, EnsureOrigin, EnsureOriginWithArg, Get, HandleLifetime,
 		OnKilledAccount, OnNewAccount, OnRuntimeUpgrade, OriginTrait, PalletInfo, SortedMembers,
 		StoredMap, TypedGet,
 	},
@@ -372,6 +372,7 @@ pub mod pallet {
 			type PreInherents = ();
 			type PostInherents = ();
 			type PostTransactions = ();
+			type DispatchGuard = ();
 		}
 
 		/// Default configurations of this pallet in a solochain environment.
@@ -474,6 +475,7 @@ pub mod pallet {
 			type PreInherents = ();
 			type PostInherents = ();
 			type PostTransactions = ();
+			type DispatchGuard = ();
 		}
 
 		/// Default configurations of this pallet in a relay-chain environment.
@@ -690,6 +692,10 @@ pub mod pallet {
 		///
 		/// See `frame_executive::block_flowchart` for a in-depth explanation when it runs.
 		type PostTransactions: PostTransactions;
+
+		/// The dispatch guard to use in dispatchable.
+		#[pallet::no_default_bounds]
+		type DispatchGuard: DispatchGuard<Self::RuntimeCall>;
 	}
 
 	#[pallet::pallet]
@@ -2385,6 +2391,23 @@ impl<T: Config> Pallet<T> {
 		}
 
 		Ok(())
+	}
+
+	pub fn check_dispatch_guard(
+		origin: &T::RuntimeOrigin,
+		call: &T::RuntimeCall,
+	) -> DispatchResultWithPostInfo {
+		// Root bypasses the dispatch guard.
+		if origin.caller().is_root() {
+			return Ok(().into());
+		}
+
+		// Wrap the dispatch guard in a transaction layer and we rollback
+		// to prevent any writes.
+		with_transaction(|| {
+			let result = T::DispatchGuard::check(origin, call);
+			TransactionOutcome::Rollback(result)
+		})
 	}
 }
 

--- a/substrate/frame/system/src/mock.rs
+++ b/substrate/frame/system/src/mock.rs
@@ -96,10 +96,60 @@ impl Config for Test {
 	type OnKilledAccount = RecordKilled;
 	type MultiBlockMigrator = MockedMigrator;
 	type Nonce = TypeWithDefault<u64, DefaultNonceProvider>;
+	type DispatchGuard = (DispatchGuard1, DispatchGuard2, DispatchGuard3);
 }
 
 parameter_types! {
 	pub static Ongoing: bool = false;
+}
+
+parameter_types! {
+	pub static DispatchGuard1ShouldFail: bool = false;
+	pub static DispatchGuard1StorageWrite: bool = false;
+	pub static DispatchGuard2ShouldFail: bool = false;
+	pub static DispatchGuard3ShouldFail: bool = false;
+}
+
+pub struct DispatchGuard1;
+impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for DispatchGuard1 {
+	fn check(
+		_origin: &<Test as Config>::RuntimeOrigin,
+		_call: &<Test as Config>::RuntimeCall,
+	) -> frame_support::dispatch::DispatchResultWithPostInfo {
+		if DispatchGuard1StorageWrite::get() {
+			frame_support::storage::unhashed::put_raw(b"dispatch_guard_write", b"written");
+		}
+		if DispatchGuard1ShouldFail::get() {
+			return Err(sp_runtime::DispatchError::Other("first guard rejected").into());
+		}
+		Ok(().into())
+	}
+}
+
+pub struct DispatchGuard2;
+impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for DispatchGuard2 {
+	fn check(
+		_origin: &<Test as Config>::RuntimeOrigin,
+		_call: &<Test as Config>::RuntimeCall,
+	) -> frame_support::dispatch::DispatchResultWithPostInfo {
+		if DispatchGuard2ShouldFail::get() {
+			return Err(sp_runtime::DispatchError::Other("second guard rejected").into());
+		}
+		Ok(().into())
+	}
+}
+
+pub struct DispatchGuard3;
+impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for DispatchGuard3 {
+	fn check(
+		_origin: &<Test as Config>::RuntimeOrigin,
+		_call: &<Test as Config>::RuntimeCall,
+	) -> frame_support::dispatch::DispatchResultWithPostInfo {
+		if DispatchGuard3ShouldFail::get() {
+			return Err(sp_runtime::DispatchError::Other("third guard rejected").into());
+		}
+		Ok(().into())
+	}
 }
 
 pub struct MockedMigrator;

--- a/substrate/frame/system/src/tests.rs
+++ b/substrate/frame/system/src/tests.rs
@@ -964,3 +964,121 @@ fn reclaim_works() {
 		assert_eq!(crate::ExtrinsicWeightReclaimed::<Test>::get(), Weight::zero());
 	});
 }
+
+#[test]
+fn dispatch_guard_root_bypasses() {
+	new_test_ext().execute_with(|| {
+		// Root should always bypass the dispatch guard, even if all guards would reject.
+		mock::DispatchGuard1ShouldFail::set(true);
+		mock::DispatchGuard2ShouldFail::set(true);
+		mock::DispatchGuard3ShouldFail::set(true);
+		let origin = RuntimeOrigin::root();
+		assert_ok!(System::check_dispatch_guard(&origin, CALL));
+	});
+}
+
+#[test]
+fn dispatch_guard_signed_passes_when_all_guards_allow() {
+	new_test_ext().execute_with(|| {
+		let origin = RuntimeOrigin::signed(1);
+		assert_ok!(System::check_dispatch_guard(&origin, CALL));
+	});
+}
+
+#[test]
+fn dispatch_guard_signed_fails_when_first_guard_rejects() {
+	new_test_ext().execute_with(|| {
+		mock::DispatchGuard1ShouldFail::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		assert_noop!(
+			System::check_dispatch_guard(&origin, CALL),
+			DispatchError::Other("first guard rejected")
+		);
+	});
+}
+
+#[test]
+fn dispatch_guard_none_origin_fails_when_guard_rejects() {
+	new_test_ext().execute_with(|| {
+		mock::DispatchGuard1ShouldFail::set(true);
+		let origin = RuntimeOrigin::none();
+		assert_noop!(
+			System::check_dispatch_guard(&origin, CALL),
+			DispatchError::Other("first guard rejected")
+		);
+	});
+}
+
+#[test]
+fn dispatch_guard_rolls_back_storage_writes() {
+	new_test_ext().execute_with(|| {
+		// Enable storage writes inside the first guard.
+		mock::DispatchGuard1StorageWrite::set(true);
+
+		let origin = RuntimeOrigin::signed(1);
+		assert_ok!(System::check_dispatch_guard(&origin, CALL));
+
+		// Storage write from inside the guard must have been rolled back.
+		assert!(!frame_support::storage::unhashed::exists(b"dispatch_guard_write"));
+	});
+}
+
+#[test]
+fn dispatch_guard_rolls_back_storage_writes_on_failure() {
+	new_test_ext().execute_with(|| {
+		// Enable storage writes and make the guard fail.
+		mock::DispatchGuard1StorageWrite::set(true);
+		mock::DispatchGuard1ShouldFail::set(true);
+
+		let origin = RuntimeOrigin::signed(1);
+		assert_noop!(
+			System::check_dispatch_guard(&origin, CALL),
+			DispatchError::Other("first guard rejected")
+		);
+
+		// Storage write must be rolled back regardless of guard outcome.
+		assert!(!frame_support::storage::unhashed::exists(b"dispatch_guard_write"));
+	});
+}
+
+#[test]
+fn dispatch_guard_tuple_second_guard_rejects() {
+	new_test_ext().execute_with(|| {
+		// First guard passes, second rejects — should surface the second guard's error.
+		mock::DispatchGuard2ShouldFail::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		assert_noop!(
+			System::check_dispatch_guard(&origin, CALL),
+			DispatchError::Other("second guard rejected")
+		);
+	});
+}
+
+#[test]
+fn dispatch_guard_tuple_third_guard_rejects() {
+	new_test_ext().execute_with(|| {
+		// First two guards pass, third rejects.
+		mock::DispatchGuard3ShouldFail::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		assert_noop!(
+			System::check_dispatch_guard(&origin, CALL),
+			DispatchError::Other("third guard rejected")
+		);
+	});
+}
+
+#[test]
+fn dispatch_guard_tuple_first_guard_short_circuits() {
+	new_test_ext().execute_with(|| {
+		// All three guards would reject, but the first one should short-circuit
+		// and we should see its error, not the others.
+		mock::DispatchGuard1ShouldFail::set(true);
+		mock::DispatchGuard2ShouldFail::set(true);
+		mock::DispatchGuard3ShouldFail::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		assert_noop!(
+			System::check_dispatch_guard(&origin, CALL),
+			DispatchError::Other("first guard rejected")
+		);
+	});
+}


### PR DESCRIPTION
polkadot-stable2506-2-otf-patches without the MEV shield stuff, only DispatchGuard.

This was already merged previously but the `polkadot-stable2506-2-otf-patches` was reset to remove MEV shield and apply it only in a 2nd release.

See #8 for description