### PR TITLE
Shielded transactions support in block proposer (with crypto in WASM)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24645,6 +24645,7 @@ dependencies = [
  "async-trait",
  "chacha20poly1305",
  "futures",
+ "hex",
  "log",
  "ml-kem",
  "parity-scale-codec",
@@ -24665,6 +24666,7 @@ dependencies = [
  "scale-info",
  "sp-api 37.0.0",
  "sp-externalities 0.30.0",
+ "sp-inherents",
  "sp-runtime 42.0.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8014,6 +8014,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8030,7 +8039,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -8984,6 +8993,16 @@ dependencies = [
  "hash-db",
  "hash256-std-hasher",
  "tiny-keccak",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -10301,6 +10320,19 @@ dependencies = [
  "rand_distr",
  "subtle 2.5.0",
  "thiserror 1.0.65",
+ "zeroize",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee19a45f916d98f24a551cc9a2cdae705a040e66f3cbc4f3a282ea6a2e982"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3 0.10.8",
  "zeroize",
 ]
 
@@ -14177,7 +14209,7 @@ checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
  "rand 0.8.5",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -17708,7 +17740,7 @@ checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -17754,7 +17786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.98",
@@ -19236,10 +19268,13 @@ dependencies = [
 name = "sc-basic-authorship"
 version = "0.50.0"
 dependencies = [
+ "chacha20poly1305",
  "futures",
  "log",
+ "ml-kem",
  "parity-scale-codec",
  "parking_lot 0.12.3",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-proposer-metrics",
@@ -19252,6 +19287,7 @@ dependencies = [
  "sp-core 37.0.0",
  "sp-inherents",
  "sp-runtime 42.0.0",
+ "stc-shield",
  "stp-shield",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
@@ -24605,6 +24641,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "stc-shield"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chacha20poly1305",
+ "futures",
+ "log",
+ "ml-kem",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "sc-client-api",
+ "sc-service",
+ "sp-consensus",
+ "sp-inherents",
+ "sp-runtime 42.0.0",
+ "stp-shield",
+]
+
+[[package]]
 name = "stp-shield"
 version = "0.1.0"
 dependencies = [
@@ -24998,6 +25054,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-trie 40.0.0",
  "sp-version 40.0.0",
+ "stp-shield",
  "substrate-test-runtime-client",
  "substrate-wasm-builder",
  "tracing",
@@ -26702,9 +26759,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24643,7 +24643,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "chacha20poly1305",
  "futures",
  "hex",
  "log",
@@ -24665,7 +24664,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 37.0.0",
- "sp-externalities 0.30.0",
  "sp-inherents",
  "sp-runtime 42.0.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19252,6 +19252,7 @@ dependencies = [
  "sp-core 37.0.0",
  "sp-inherents",
  "sp-runtime 42.0.0",
+ "stp-shield",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
 ]
@@ -24601,6 +24602,17 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "stp-shield"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 37.0.0",
+ "sp-externalities 0.30.0",
+ "sp-runtime 42.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19268,13 +19268,10 @@ dependencies = [
 name = "sc-basic-authorship"
 version = "0.50.0"
 dependencies = [
- "chacha20poly1305",
  "futures",
  "log",
- "ml-kem",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-proposer-metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -594,6 +594,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 	'cfg(ignore_flaky_test)',
 	'cfg(substrate_runtime)',
 ] }
+mismatched_lifetime_syntaxes = "allow"
 
 [workspace.lints.clippy]
 all = { level = "allow", priority = 0 }
@@ -1467,6 +1468,8 @@ zeroize = { version = "1.7.0", default-features = false }
 zombienet-orchestrator = { version = "0.3.0" }
 zombienet-sdk = { version = "0.3.0" }
 zstd = { version = "0.12.4", default-features = false }
+
+stp-shield = { path = "/Users/loris/Work/subtensor/primitives/shield", default-features = false }
 
 [profile.release]
 # Polkadot runtime requires unwinding.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1470,6 +1470,9 @@ zombienet-sdk = { version = "0.3.0" }
 zstd = { version = "0.12.4", default-features = false }
 
 stp-shield = { path = "/Users/loris/Work/subtensor/primitives/shield", default-features = false }
+stc-shield = { path = "/Users/loris/Work/subtensor/client/shield", default-features = false }
+ml-kem = { version = "0.2.2", default-features = false }
+chacha20poly1305 = { version = "0.10", default-features = false }
 
 [profile.release]
 # Polkadot runtime requires unwinding.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1471,8 +1471,6 @@ zstd = { version = "0.12.4", default-features = false }
 
 stp-shield = { path = "/Users/loris/Work/subtensor/primitives/shield", default-features = false }
 stc-shield = { path = "/Users/loris/Work/subtensor/client/shield", default-features = false }
-ml-kem = { version = "0.2.2", default-features = false }
-chacha20poly1305 = { version = "0.10", default-features = false }
 
 [profile.release]
 # Polkadot runtime requires unwinding.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1469,8 +1469,10 @@ zombienet-orchestrator = { version = "0.3.0" }
 zombienet-sdk = { version = "0.3.0" }
 zstd = { version = "0.12.4", default-features = false }
 
-stp-shield = { path = "/Users/loris/Work/subtensor/primitives/shield", default-features = false }
-stc-shield = { path = "/Users/loris/Work/subtensor/client/shield", default-features = false }
+stp-shield = { path = "substrate/primitives/shield", default-features = false }
+stc-shield = { path = "substrate/client/shield", default-features = false }
+ml-kem = { version = "0.2.2", default-features = false }
+chacha20poly1305 = { version = "0.10", default-features = false }
 
 [profile.release]
 # Polkadot runtime requires unwinding.

--- a/substrate/client/basic-authorship/Cargo.toml
+++ b/substrate/client/basic-authorship/Cargo.toml
@@ -48,3 +48,7 @@ parking_lot = { workspace = true, default-features = true }
 sc-client-api = { default-features = true, workspace = true }
 sc-transaction-pool = { default-features = true, workspace = true }
 substrate-test-runtime-client = { workspace = true }
+stc-shield = { workspace = true, default-features = true }
+rand.workspace = true
+chacha20poly1305 = { workspace = true, features = ["std"] }
+ml-kem = { workspace = true, features = ["zeroize"] }

--- a/substrate/client/basic-authorship/Cargo.toml
+++ b/substrate/client/basic-authorship/Cargo.toml
@@ -41,6 +41,7 @@ sp-inherents.default-features = true
 sp-inherents.workspace = true
 sp-runtime.default-features = true
 sp-runtime.workspace = true
+stp-shield = { workspace = true, default-features = true}
 
 [dev-dependencies]
 parking_lot = { workspace = true, default-features = true }

--- a/substrate/client/basic-authorship/Cargo.toml
+++ b/substrate/client/basic-authorship/Cargo.toml
@@ -49,6 +49,3 @@ sc-client-api = { default-features = true, workspace = true }
 sc-transaction-pool = { default-features = true, workspace = true }
 substrate-test-runtime-client = { workspace = true }
 stc-shield = { workspace = true, default-features = true }
-rand.workspace = true
-chacha20poly1305 = { workspace = true, features = ["std"] }
-ml-kem = { workspace = true, features = ["zeroize"] }

--- a/substrate/client/basic-authorship/README.md
+++ b/substrate/client/basic-authorship/README.md
@@ -1,5 +1,17 @@
 Basic implementation of block-authoring logic.
 
+## MEV Shield integration
+
+When a `ShieldKeystorePtr` is provided to `ProposerFactory`, the proposer will handle shielded transactions during block authoring:
+
+1. Each pending transaction is inspected via the `ShieldApi` runtime API to detect whether it is a shielded wrapper.
+2. Shielded transactions are decrypted on the spot using the keystore registered as a runtime extension. Block size accounting is adjusted to reflect the inner plaintext size rather than the ciphertext size.
+3. If the wrapper extrinsic applies successfully, the decrypted inner transaction is immediately pushed into the block as a second extrinsic.
+
+Decryption happens only at block authoring time, never earlier. Setting the environment variable `SUBSTRATE_SKIP_SHIELDED_TXS=1` causes the proposer to skip all shielded transactions (leaving them in the pool for other authors).
+
+See [`stp-shield`](../../primitives/shield) and [`stc-shield`](../shield) for the underlying types and keystore implementation.
+
 # Example
 
 ```rust

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -466,6 +466,12 @@ where
 				.try_decode_shielded_tx(self.parent_hash, pending_tx_data.clone())
 				.ok()
 				.flatten();
+			
+			if skip_shielded_txs() && maybe_shielded_tx.is_some() {
+				// We don't report the transaction as invalid so it stay in the pool
+				// and may be gossiped to other block authors that allow them.
+				continue;
+			}
 
 			let pending_tx_data_size = if let Some(shielded_tx) = &maybe_shielded_tx {
 				// The ciphertext length for XChaCha20Poly1305 is the length of the plaintext + 16 bytes
@@ -522,6 +528,7 @@ where
 						continue;
 					};
 
+					// The shield wrapper paid the unshield fee.
 					if let Err(end_reason) = self.unshield_and_push_inner_tx(
 						&mut api,
 						block_builder,
@@ -696,6 +703,10 @@ where
 			"hash" => ?<Block as BlockT>::Hash::from(block.header().hash()),
 		);
 	}
+}
+
+fn skip_shielded_txs() -> bool {
+	std::env::var("SUBSTRATE_SKIP_SHIELDED_TXS").is_ok_and(|v| v.trim() == "1")
 }
 
 #[cfg(test)]

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -29,8 +29,8 @@ use futures::{
 use log::{debug, error, info, trace, warn};
 use sc_block_builder::{BlockBuilderApi, BlockBuilderBuilder};
 use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_INFO};
-use sc_transaction_pool_api::{InPoolTransaction, TransactionPool, TxInvalidityReportMap};
-use sp_api::{ApiExt, CallApiAt, ProvideRuntimeApi};
+use sc_transaction_pool_api::{InPoolTransaction, TransactionPool, TxHash, TxInvalidityReportMap};
+use sp_api::{ApiExt, ApiRef, CallApiAt, ProvideRuntimeApi};
 use sp_blockchain::{ApplyExtrinsicFailed::Validity, Error::ApplyExtrinsicFailed, HeaderBackend};
 use sp_consensus::{DisableProofRecording, EnableProofRecording, ProofRecording, Proposal};
 use sp_core::traits::SpawnNamed;
@@ -40,6 +40,7 @@ use sp_runtime::{
 	Digest, ExtrinsicInclusionMode, Percent, SaturatedConversion,
 };
 use std::{marker::PhantomData, pin::Pin, sync::Arc, time};
+use stp_shield::{ShieldApi, ShieldKeystoreExt, ShieldKeystorePtr, ShieldedTransaction};
 
 use prometheus_endpoint::Registry as PrometheusRegistry;
 use sc_proposer_metrics::{EndProposingReason, MetricsLink as PrometheusMetrics};
@@ -82,6 +83,8 @@ pub struct ProposerFactory<A, C, PR> {
 	telemetry: Option<TelemetryHandle>,
 	/// When estimating the block size, should the proof be included?
 	include_proof_in_block_size_estimation: bool,
+	/// The MEV shield keystore.
+	shield_keystore: ShieldKeystorePtr,
 	/// phantom member to pin the `ProofRecording` type.
 	_phantom: PhantomData<PR>,
 }
@@ -97,6 +100,7 @@ impl<A, C, PR> Clone for ProposerFactory<A, C, PR> {
 			soft_deadline_percent: self.soft_deadline_percent,
 			telemetry: self.telemetry.clone(),
 			include_proof_in_block_size_estimation: self.include_proof_in_block_size_estimation,
+			shield_keystore: self.shield_keystore.clone(),
 			_phantom: self._phantom,
 		}
 	}
@@ -113,6 +117,7 @@ impl<A, C> ProposerFactory<A, C, DisableProofRecording> {
 		transaction_pool: Arc<A>,
 		prometheus: Option<&PrometheusRegistry>,
 		telemetry: Option<TelemetryHandle>,
+		shield_keystore: ShieldKeystorePtr,
 	) -> Self {
 		ProposerFactory {
 			spawn_handle: Box::new(spawn_handle),
@@ -123,6 +128,7 @@ impl<A, C> ProposerFactory<A, C, DisableProofRecording> {
 			telemetry,
 			client,
 			include_proof_in_block_size_estimation: false,
+			shield_keystore,
 			_phantom: PhantomData,
 		}
 	}
@@ -141,6 +147,7 @@ impl<A, C> ProposerFactory<A, C, EnableProofRecording> {
 		transaction_pool: Arc<A>,
 		prometheus: Option<&PrometheusRegistry>,
 		telemetry: Option<TelemetryHandle>,
+		shield_keystore: ShieldKeystorePtr,
 	) -> Self {
 		ProposerFactory {
 			client,
@@ -151,6 +158,7 @@ impl<A, C> ProposerFactory<A, C, EnableProofRecording> {
 			soft_deadline_percent: DEFAULT_SOFT_DEADLINE_PERCENT,
 			telemetry,
 			include_proof_in_block_size_estimation: true,
+			shield_keystore,
 			_phantom: PhantomData,
 		}
 	}
@@ -221,6 +229,7 @@ where
 			default_block_size_limit: self.default_block_size_limit,
 			soft_deadline_percent: self.soft_deadline_percent,
 			telemetry: self.telemetry.clone(),
+			shield_keystore: self.shield_keystore.clone(),
 			_phantom: PhantomData,
 			include_proof_in_block_size_estimation: self.include_proof_in_block_size_estimation,
 		};
@@ -234,7 +243,7 @@ where
 	A: TransactionPool<Block = Block> + 'static,
 	Block: BlockT,
 	C: HeaderBackend<Block> + ProvideRuntimeApi<Block> + CallApiAt<Block> + Send + Sync + 'static,
-	C::Api: ApiExt<Block> + BlockBuilderApi<Block>,
+	C::Api: ApiExt<Block> + BlockBuilderApi<Block> + ShieldApi<Block>,
 	PR: ProofRecording,
 {
 	type CreateProposer = future::Ready<Result<Self::Proposer, Self::Error>>;
@@ -259,6 +268,7 @@ pub struct Proposer<Block: BlockT, C, A: TransactionPool, PR> {
 	include_proof_in_block_size_estimation: bool,
 	soft_deadline_percent: Percent,
 	telemetry: Option<TelemetryHandle>,
+	shield_keystore: ShieldKeystorePtr,
 	_phantom: PhantomData<PR>,
 }
 
@@ -267,7 +277,7 @@ where
 	A: TransactionPool<Block = Block> + 'static,
 	Block: BlockT,
 	C: HeaderBackend<Block> + ProvideRuntimeApi<Block> + CallApiAt<Block> + Send + Sync + 'static,
-	C::Api: ApiExt<Block> + BlockBuilderApi<Block>,
+	C::Api: ApiExt<Block> + BlockBuilderApi<Block> + ShieldApi<Block>,
 	PR: ProofRecording,
 {
 	type Proposal =
@@ -318,7 +328,7 @@ where
 	A: TransactionPool<Block = Block>,
 	Block: BlockT,
 	C: HeaderBackend<Block> + ProvideRuntimeApi<Block> + CallApiAt<Block> + Send + Sync + 'static,
-	C::Api: ApiExt<Block> + BlockBuilderApi<Block>,
+	C::Api: ApiExt<Block> + BlockBuilderApi<Block> + ShieldApi<Block>,
 	PR: ProofRecording,
 {
 	async fn propose_with(
@@ -449,9 +459,31 @@ where
 			let pending_tx_data = (**pending_tx.data()).clone();
 			let pending_tx_hash = pending_tx.hash().clone();
 
+			let mut api = self.client.runtime_api();
+			api.register_extension(ShieldKeystoreExt::from(self.shield_keystore.clone()));
+
+			let maybe_shielded_tx = api
+				.try_decode_shielded_tx(self.parent_hash, pending_tx_data.clone())
+				.ok()
+				.flatten();
+
+			let pending_tx_data_size = if let Some(shielded_tx) = &maybe_shielded_tx {
+				// The ciphertext length for XChaCha20Poly1305 is the length of the plaintext + 16 bytes
+				// for the tag (source: https://www.rfc-editor.org/rfc/rfc8439#section-2.8) so we need
+				// to subtract it from the ciphertext length to get the plaintext length
+				const TAG_SIZE: usize = 16;
+				let unshielded_tx_size = shielded_tx.aead_ct.len().saturating_sub(TAG_SIZE);
+
+				// We will push the shielded tx wrapper and the unshielded inner tx to the block builder
+				// so we should account for both when estimating the block size
+				pending_tx_data.encoded_size() + unshielded_tx_size
+			} else {
+				pending_tx_data.encoded_size()
+			};
+
 			let block_size =
 				block_builder.estimate_block_size(self.include_proof_in_block_size_estimation);
-			if block_size + pending_tx_data.encoded_size() > block_size_limit {
+			if block_size + pending_tx_data_size > block_size_limit {
 				pending_iterator.report_invalid(&pending_tx);
 				if skipped < MAX_SKIPPED_TRANSACTIONS {
 					skipped += 1;
@@ -479,31 +511,34 @@ where
 				}
 			}
 
-			trace!(target: LOG_TARGET, "[{:?}] Pushing to the block.", pending_tx_hash);
+			let tx_type = if maybe_shielded_tx.is_some() { "shield wrapper" } else { "normal" };
+			trace!(target: LOG_TARGET, "[{:?}] Pushing {} transaction to the block.", pending_tx_hash, tx_type);
 			match sc_block_builder::BlockBuilder::push(block_builder, pending_tx_data) {
 				Ok(()) => {
 					transaction_pushed = true;
-					trace!(target: LOG_TARGET, "[{:?}] Pushed to the block.", pending_tx_hash);
+					trace!(target: LOG_TARGET, "[{:?}] Pushed {} transaction to the block.", pending_tx_hash, tx_type);
+
+					let Some(shielded_tx) = maybe_shielded_tx else {
+						continue;
+					};
+
+					if let Err(end_reason) = self.unshield_and_push_inner_tx(
+						&mut api,
+						block_builder,
+						pending_tx_hash,
+						shielded_tx,
+						&mut skipped,
+						soft_deadline,
+					) {
+						break end_reason;
+					}
 				},
 				Err(ApplyExtrinsicFailed(Validity(e))) if e.exhausted_resources() => {
 					pending_iterator.report_invalid(&pending_tx);
-					if skipped < MAX_SKIPPED_TRANSACTIONS {
-						skipped += 1;
-						debug!(target: LOG_TARGET,
-							"Block seems full, but will try {} more transactions before quitting.",
-							MAX_SKIPPED_TRANSACTIONS - skipped,
-						);
-					} else if (self.now)() < soft_deadline {
-						debug!(target: LOG_TARGET,
-							"Block seems full, but we still have time before the soft deadline, \
-							 so we will try a bit more before quitting."
-						);
-					} else {
-						debug!(
-							target: LOG_TARGET,
-							"Reached block weight limit, proceeding with proposing."
-						);
-						break EndProposingReason::HitBlockWeightLimit
+					if let Err(end_reason) =
+						self.report_exhausted_resources(&mut skipped, soft_deadline)
+					{
+						break end_reason;
 					}
 				},
 				Err(e) => {
@@ -532,6 +567,69 @@ where
 
 		self.transaction_pool.report_invalid(Some(self.parent_hash), unqueue_invalid);
 		Ok(end_reason)
+	}
+
+	fn unshield_and_push_inner_tx(
+		&self,
+		api: &mut ApiRef<'_, C::Api>,
+		block_builder: &mut sc_block_builder::BlockBuilder<'_, Block, C>,
+		shielded_tx_hash: TxHash<A>,
+		shielded_tx: ShieldedTransaction,
+		skipped: &mut usize,
+		soft_deadline: time::Instant,
+	) -> Result<(), EndProposingReason> {
+		let Some(unshielded_tx_data) =
+			api.try_unshield_tx(self.parent_hash, shielded_tx).ok().flatten()
+		else {
+			debug!(target: LOG_TARGET, "[{:?}] Failed to unshield transaction", shielded_tx_hash);
+			return Ok(());
+		};
+		trace!(target: LOG_TARGET, "[{:?}] Unshielded inner transaction: {:?}", shielded_tx_hash, unshielded_tx_data);
+
+		match sc_block_builder::BlockBuilder::push(block_builder, unshielded_tx_data) {
+			Ok(()) => {
+				debug!(target: LOG_TARGET, "[{:?}] Pushed unshielded transaction to the block.", shielded_tx_hash);
+			},
+			Err(ApplyExtrinsicFailed(Validity(e))) if e.exhausted_resources() => {
+				debug!(target: LOG_TARGET, "[{:?}] Unshielded transaction exhausted resources", shielded_tx_hash);
+				self.report_exhausted_resources(skipped, soft_deadline)?;
+			},
+			Err(e) => {
+				debug!(
+					target: LOG_TARGET,
+					"[{:?}] Invalid unshielded transaction: {} at: {}", shielded_tx_hash, e, self.parent_hash
+				);
+			},
+		}
+
+		Ok(())
+	}
+
+	fn report_exhausted_resources(
+		&self,
+		skipped: &mut usize,
+		soft_deadline: time::Instant,
+	) -> Result<(), EndProposingReason> {
+		if *skipped < MAX_SKIPPED_TRANSACTIONS {
+			*skipped += 1;
+			debug!(target: LOG_TARGET,
+				"Block seems full, but will try {} more transactions before quitting.",
+				MAX_SKIPPED_TRANSACTIONS - *skipped,
+			);
+			Ok(())
+		} else if (self.now)() < soft_deadline {
+			debug!(target: LOG_TARGET,
+				"Block seems full, but we still have time before the soft deadline, \
+				 so we will try a bit more before quitting."
+			);
+			Ok(())
+		} else {
+			debug!(
+				target: LOG_TARGET,
+				"Reached block weight limit, proceeding with proposing."
+			);
+			Err(EndProposingReason::HitBlockWeightLimit)
+		}
 	}
 
 	/// Prints a summary and does telemetry + metrics.

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -40,7 +40,7 @@ use sp_runtime::{
 	Digest, ExtrinsicInclusionMode, Percent, SaturatedConversion,
 };
 use std::{marker::PhantomData, pin::Pin, sync::Arc, time};
-use stp_shield::{ShieldApi, ShieldKeystoreExt, ShieldKeystorePtr, ShieldedTransaction};
+use stp_shield::{ShieldApi, ShieldKeystorePtr, ShieldedTransaction};
 
 use prometheus_endpoint::Registry as PrometheusRegistry;
 use sc_proposer_metrics::{EndProposingReason, MetricsLink as PrometheusMetrics};
@@ -460,8 +460,7 @@ where
 			let pending_tx_data = (**pending_tx.data()).clone();
 			let pending_tx_hash = pending_tx.hash().clone();
 
-			let mut api = self.client.runtime_api();
-			api.register_extension(ShieldKeystoreExt::from(self.shield_keystore.clone()));
+			let api = self.client.runtime_api();
 
 			let maybe_shielded_tx = api
 				.try_decode_shielded_tx(self.parent_hash, pending_tx_data.clone())
@@ -532,7 +531,7 @@ where
 
 					// The shield wrapper paid the unshield fee.
 					if let Err(end_reason) = self.unshield_and_push_inner_tx(
-						&mut api,
+						&api,
 						block_builder,
 						pending_tx_hash,
 						shielded_tx,
@@ -580,15 +579,27 @@ where
 
 	fn unshield_and_push_inner_tx(
 		&self,
-		api: &mut ApiRef<'_, C::Api>,
+		api: &ApiRef<'_, C::Api>,
 		block_builder: &mut sc_block_builder::BlockBuilder<'_, Block, C>,
 		shielded_tx_hash: TxHash<A>,
 		shielded_tx: ShieldedTransaction,
 		skipped: &mut usize,
 		soft_deadline: time::Instant,
 	) -> Result<(), EndProposingReason> {
+		let dec_key_bytes = self
+			.shield_keystore
+			.current_dec_key()
+			.map_err(|e| {
+				debug!(target: LOG_TARGET, "[{:?}] Failed to get decapsulation key: {}", shielded_tx_hash, e);
+			})
+			.ok();
+
+		let Some(dec_key_bytes) = dec_key_bytes else {
+			return Ok(());
+		};
+
 		let Some(unshielded_tx_data) =
-			api.try_unshield_tx(self.parent_hash, shielded_tx).ok().flatten()
+			api.try_unshield_tx(self.parent_hash, dec_key_bytes, shielded_tx).ok().flatten()
 		else {
 			debug!(target: LOG_TARGET, "[{:?}] Failed to unshield transaction", shielded_tx_hash);
 			return Ok(());
@@ -1549,21 +1560,11 @@ mod tests {
 			Ok(())
 		}
 
-		fn next_public_key(&self) -> TraitResult<Vec<u8>> {
+		fn next_enc_key(&self) -> TraitResult<Vec<u8>> {
 			Ok(Vec::new())
 		}
 
-		fn mlkem768_decapsulate(&self, _ciphertext: &[u8]) -> TraitResult<[u8; 32]> {
-			Ok([0u8; 32])
-		}
-
-		fn aead_decrypt(
-			&self,
-			_key: [u8; 32],
-			_nonce: [u8; 24],
-			_msg: &[u8],
-			_aad: &[u8],
-		) -> TraitResult<Vec<u8>> {
+		fn current_dec_key(&self) -> TraitResult<Vec<u8>> {
 			Ok(Vec::new())
 		}
 	}

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -715,17 +715,8 @@ fn skip_shielded_txs() -> bool {
 mod tests {
 	use super::*;
 
-	use chacha20poly1305::{
-		aead::{Aead, Payload},
-		KeyInit, XChaCha20Poly1305, XNonce,
-	};
 	use futures::executor::block_on;
-	use ml_kem::{
-		kem::{Decapsulate, DecapsulationKey, EncapsulationKey},
-		Ciphertext, EncodedSizeUser, KemCore, MlKem768, MlKem768Params,
-	};
 	use parking_lot::Mutex;
-	use rand::rngs::OsRng;
 	use sc_client_api::{Backend, TrieCacheContext};
 	use sc_transaction_pool::BasicPool;
 	use sc_transaction_pool_api::{ChainEvent, MaintainedTransactionPool, TransactionSource};
@@ -733,10 +724,13 @@ mod tests {
 	use sp_blockchain::HeaderBackend;
 	use sp_consensus::{BlockOrigin, Environment, Proposer};
 	use sp_runtime::{generic::BlockId, traits::NumberFor, Perbill};
-	use stp_shield::{Result as TraitResult, ShieldKeystore};
+	use stp_shield::{Result as TraitResult, ShieldKeystore, ShieldedTransaction};
 	use substrate_test_runtime_client::{
 		prelude::*,
-		runtime::{Block as TestBlock, Extrinsic, ExtrinsicBuilder, Transfer},
+		runtime::{
+			Block as TestBlock, Extrinsic, ExtrinsicBuilder, Transfer,
+			SHIELD_TEST_DECODE_KEY, SHIELD_TEST_UNSHIELD_KEY,
+		},
 		TestClientBuilder, TestClientBuilderExt,
 	};
 
@@ -777,7 +771,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore::new());
+		let shield_keystore = Arc::new(TestShieldKeystore);
 
 		let hashof0 = client.info().genesis_hash;
 		block_on(txpool.submit_at(hashof0, SOURCE, vec![extrinsic(0), extrinsic(1)])).unwrap();
@@ -837,7 +831,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore::new());
+		let shield_keystore = Arc::new(TestShieldKeystore);
 
 		let mut proposer_factory = ProposerFactory::new(
 			spawner.clone(),
@@ -881,7 +875,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore::new());
+		let shield_keystore = Arc::new(TestShieldKeystore);
 
 		let genesis_hash = client.info().best_hash;
 
@@ -944,7 +938,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore::new());
+		let shield_keystore = Arc::new(TestShieldKeystore);
 
 		let medium = |nonce| {
 			ExtrinsicBuilder::new_fill_block(Perbill::from_parts(MEDIUM))
@@ -1059,7 +1053,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore::new());
+		let shield_keystore = Arc::new(TestShieldKeystore);
 		let genesis_hash = client.info().genesis_hash;
 		let genesis_header = client.expect_header(genesis_hash).expect("there should be header");
 
@@ -1172,7 +1166,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore::new());
+		let shield_keystore = Arc::new(TestShieldKeystore);
 		let genesis_hash = client.info().genesis_hash;
 
 		let tiny = |nonce| {
@@ -1248,7 +1242,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore::new());
+		let shield_keystore = Arc::new(TestShieldKeystore);
 		let genesis_hash = client.info().genesis_hash;
 
 		let tiny = |who| {
@@ -1330,17 +1324,247 @@ mod tests {
 		);
 	}
 
-	struct TestShieldKeystore {
-		enc_key: EncapsulationKey<MlKem768Params>,
-		dec_key: DecapsulationKey<MlKem768Params>,
+	// --- Shielded transaction tests ---
+
+	/// Creates a test client with mock shielded tx data injected into genesis storage.
+	fn shielded_test_client(
+		decode: Option<ShieldedTransaction>,
+		unshield: Option<Extrinsic>,
+	) -> Arc<substrate_test_runtime_client::TestClient> {
+		let mut builder = TestClientBuilder::new();
+		if let Some(tx) = decode {
+			builder = builder
+				.add_extra_storage(SHIELD_TEST_DECODE_KEY.to_vec(), tx.encode());
+		}
+		if let Some(ext) = unshield {
+			builder = builder
+				.add_extra_storage(SHIELD_TEST_UNSHIELD_KEY.to_vec(), ext.encode());
+		}
+		Arc::new(builder.build())
 	}
 
-	impl TestShieldKeystore {
-		fn new() -> Self {
-			let (dec_key, enc_key) = MlKem768::generate(&mut OsRng);
-			Self { enc_key, dec_key }
-		}
+	#[test]
+	fn shielded_tx_and_inner_tx_both_included_in_block() {
+		let client = shielded_test_client(
+			Some(mock_shielded_tx(100)),
+			Some(extrinsic(1)),
+		);
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let txpool = Arc::from(BasicPool::new_full(
+			Default::default(),
+			true.into(),
+			None,
+			spawner.clone(),
+			client.clone(),
+		));
+		let shield_keystore = Arc::new(TestShieldKeystore);
+		let genesis_hash = client.info().genesis_hash;
+
+		// Submit one extrinsic (this becomes the wrapper)
+		block_on(txpool.submit_at(genesis_hash, SOURCE, vec![extrinsic(0)])).unwrap();
+		block_on(txpool.maintain(chain_event(
+			client.expect_header(genesis_hash).expect("there should be header"),
+		)));
+
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
+
+		let proposer = block_on(proposer_factory.init(
+			&client.expect_header(genesis_hash).unwrap(),
+		))
+		.unwrap();
+
+		let deadline = time::Duration::from_secs(9);
+		let block =
+			block_on(proposer.propose(Default::default(), Default::default(), deadline, None))
+				.map(|r| r.block)
+				.unwrap();
+
+		// Block should contain: wrapper extrinsic + unshielded inner extrinsic
+		assert_eq!(block.extrinsics().len(), 2);
 	}
+
+	#[test]
+	fn shielded_tx_included_when_unshielding_fails() {
+		// Decode succeeds but unshielding fails (no unshield key in storage)
+		let client = shielded_test_client(
+			Some(mock_shielded_tx(100)),
+			None,
+		);
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let txpool = Arc::from(BasicPool::new_full(
+			Default::default(),
+			true.into(),
+			None,
+			spawner.clone(),
+			client.clone(),
+		));
+		let shield_keystore = Arc::new(TestShieldKeystore);
+		let genesis_hash = client.info().genesis_hash;
+
+		// Submit one extrinsic
+		block_on(txpool.submit_at(genesis_hash, SOURCE, vec![extrinsic(0)])).unwrap();
+		block_on(txpool.maintain(chain_event(
+			client.expect_header(genesis_hash).expect("there should be header"),
+		)));
+
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
+
+		let proposer = block_on(proposer_factory.init(
+			&client.expect_header(genesis_hash).unwrap(),
+		))
+		.unwrap();
+
+		let deadline = time::Duration::from_secs(9);
+		let block =
+			block_on(proposer.propose(Default::default(), Default::default(), deadline, None))
+				.map(|r| r.block)
+				.unwrap();
+
+		// Block should contain only the wrapper (inner unshielding failed gracefully)
+		assert_eq!(block.extrinsics().len(), 1);
+	}
+
+	#[test]
+	fn should_skip_shielded_txs_when_env_var_is_set() {
+		let client = shielded_test_client(
+			Some(mock_shielded_tx(100)),
+			Some(extrinsic(2)),
+		);
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let txpool = Arc::from(BasicPool::new_full(
+			Default::default(),
+			true.into(),
+			None,
+			spawner.clone(),
+			client.clone(),
+		));
+		let shield_keystore = Arc::new(TestShieldKeystore);
+		let genesis_hash = client.info().genesis_hash;
+
+		// Submit extrinsics to the pool
+		block_on(txpool.submit_at(genesis_hash, SOURCE, vec![extrinsic(0), extrinsic(1)]))
+			.unwrap();
+		block_on(txpool.maintain(chain_event(
+			client.expect_header(genesis_hash).expect("there should be header"),
+		)));
+		assert_eq!(txpool.ready().count(), 2);
+
+		// Set env var to skip shielded txs
+		let _env_guard = EnvVarGuard::set("SUBSTRATE_SKIP_SHIELDED_TXS", "1");
+
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
+
+		let proposer = block_on(proposer_factory.init(
+			&client.expect_header(genesis_hash).unwrap(),
+		))
+		.unwrap();
+
+		let deadline = time::Duration::from_secs(9);
+		let block =
+			block_on(proposer.propose(Default::default(), Default::default(), deadline, None))
+				.map(|r| r.block)
+				.unwrap();
+
+		// Block should have 0 extrinsics, all were shielded and skipped
+		assert_eq!(block.extrinsics().len(), 0);
+
+		// Transactions should still be in the pool (they weren't reported as invalid, just skipped)
+		assert_eq!(txpool.ready().count(), 2);
+	}
+
+	#[test]
+	fn block_size_accounts_for_unshielded_tx_size() {
+		let aead_ct_len = 10_000;
+		let client = shielded_test_client(
+			Some(mock_shielded_tx(aead_ct_len)),
+			Some(extrinsic(1)),
+		);
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let txpool = Arc::from(BasicPool::new_full(
+			Default::default(),
+			true.into(),
+			None,
+			spawner.clone(),
+			client.clone(),
+		));
+		let shield_keystore = Arc::new(TestShieldKeystore);
+		let genesis_hash = client.info().genesis_hash;
+		let genesis_header =
+			client.expect_header(genesis_hash).expect("there should be header");
+
+		let wrapper_tx = extrinsic(0);
+		let wrapper_encoded_size = wrapper_tx.encoded_size();
+
+		// Submit the wrapper to the pool
+		block_on(txpool.submit_at(genesis_hash, SOURCE, vec![wrapper_tx])).unwrap();
+		block_on(txpool.maintain(chain_event(genesis_header.clone())));
+
+		// Compute base block size (header + empty extrinsics vector encoding)
+		let base_block_size = {
+			let builder = BlockBuilderBuilder::new(&*client)
+				.on_parent_block(genesis_hash)
+				.with_parent_block_number(0)
+				.build()
+				.unwrap();
+			builder.estimate_block_size(false)
+		};
+
+		// aead_ct of 10_000 bytes means estimated inner = 9_984 bytes.
+		// The limit fits base + wrapper + half the estimated inner (so wrapper alone fits,
+		// but combined does not)
+		let estimated_inner_size = aead_ct_len - 16;
+		let block_size_limit = base_block_size + wrapper_encoded_size + estimated_inner_size / 2;
+
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
+
+		let proposer = block_on(proposer_factory.init(&genesis_header)).unwrap();
+
+		let deadline = time::Duration::from_secs(9);
+		let block = block_on(proposer.propose(
+			Default::default(),
+			Default::default(),
+			deadline,
+			Some(block_size_limit),
+		))
+		.map(|r| r.block)
+		.unwrap();
+
+		// Block should have 0 extrinsics, the shielded tx was too large to fit
+		// because the block size estimation accounts for wrapper + estimated inner
+		assert_eq!(block.extrinsics().len(), 0);
+	}
+
+	/// Minimal shield keystore stub, no actual decryption is performed in these tests
+	/// since the test runtime returns mock data from storage instead.
+	struct TestShieldKeystore;
 
 	impl ShieldKeystore for TestShieldKeystore {
 		fn roll_for_next_slot(&self) -> TraitResult<()> {
@@ -1348,29 +1572,53 @@ mod tests {
 		}
 
 		fn next_public_key(&self) -> TraitResult<Vec<u8>> {
-			Ok(self.enc_key.as_bytes().to_vec())
+			Ok(Vec::new())
 		}
 
-		fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> TraitResult<[u8; 32]> {
-			let ciphertext = Ciphertext::<MlKem768>::try_from(ciphertext).unwrap();
-			let shared_secret = self.dec_key.decapsulate(&ciphertext).unwrap();
-
-			Ok(shared_secret.into())
+		fn mlkem768_decapsulate(&self, _ciphertext: &[u8]) -> TraitResult<[u8; 32]> {
+			Ok([0u8; 32])
 		}
 
 		fn aead_decrypt(
 			&self,
-			key: [u8; 32],
-			nonce: [u8; 24],
-			msg: &[u8],
-			aad: &[u8],
+			_key: [u8; 32],
+			_nonce: [u8; 24],
+			_msg: &[u8],
+			_aad: &[u8],
 		) -> TraitResult<Vec<u8>> {
-			let aead = XChaCha20Poly1305::new((&key).into());
-			let nonce = XNonce::from_slice(&nonce);
-			let payload = Payload { msg, aad };
-			let decrypted = aead.decrypt(nonce, payload).unwrap();
+			Ok(Vec::new())
+		}
+	}
 
-			Ok(decrypted)
+	fn mock_shielded_tx(aead_ct_len: usize) -> ShieldedTransaction {
+		ShieldedTransaction {
+			key_hash: [0u8; 16],
+			kem_ct: vec![0u8; 32],
+			aead_ct: vec![0u8; aead_ct_len],
+			nonce: [0u8; 24],
+		}
+	}
+
+	/// RAII guard that sets an environment variable and restores the previous value on drop.
+	struct EnvVarGuard {
+		key: &'static str,
+		prev: Option<String>,
+	}
+
+	impl EnvVarGuard {
+		fn set(key: &'static str, value: &str) -> Self {
+			let prev = std::env::var(key).ok();
+			std::env::set_var(key, value);
+			Self { key, prev }
+		}
+	}
+
+	impl Drop for EnvVarGuard {
+		fn drop(&mut self) {
+			match &self.prev {
+				Some(val) => std::env::set_var(self.key, val),
+				None => std::env::remove_var(self.key),
+			}
 		}
 	}
 }

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -350,8 +350,9 @@ where
 
 		let mode = block_builder.extrinsic_inclusion_mode();
 		let end_reason = match mode {
-			ExtrinsicInclusionMode::AllExtrinsics =>
-				self.apply_extrinsics(&mut block_builder, deadline, block_size_limit).await?,
+			ExtrinsicInclusionMode::AllExtrinsics => {
+				self.apply_extrinsics(&mut block_builder, deadline, block_size_limit).await?
+			},
 			ExtrinsicInclusionMode::OnlyInherents => EndProposingReason::TransactionForbidden,
 		};
 		let (block, storage_changes, proof) = block_builder.build()?.into_inner();
@@ -394,7 +395,7 @@ where
 					error!(
 						"❌️ Mandatory inherent extrinsic returned error. Block cannot be produced."
 					);
-					return Err(ApplyExtrinsicFailed(Validity(e)))
+					return Err(ApplyExtrinsicFailed(Validity(e)));
 				},
 				Err(e) => {
 					warn!(
@@ -443,7 +444,7 @@ where
 					"No more transactions, proceeding with proposing."
 				);
 
-				break EndProposingReason::NoMoreTransactions
+				break EndProposingReason::NoMoreTransactions;
 			};
 
 			let now = (self.now)();
@@ -453,7 +454,7 @@ where
 					"Consensus deadline reached when pushing block transactions, \
 				proceeding with proposing."
 				);
-				break EndProposingReason::HitDeadline
+				break EndProposingReason::HitDeadline;
 			}
 
 			let pending_tx_data = (**pending_tx.data()).clone();
@@ -466,8 +467,9 @@ where
 				.try_decode_shielded_tx(self.parent_hash, pending_tx_data.clone())
 				.ok()
 				.flatten();
-			
+
 			if skip_shielded_txs() && maybe_shielded_tx.is_some() {
+				debug!(target: LOG_TARGET, "Skipping shielded transaction");
 				// We don't report the transaction as invalid so it stay in the pool
 				// and may be gossiped to other block authors that allow them.
 				continue;
@@ -499,7 +501,7 @@ where
 					 but will try {} more transactions before quitting.",
 						MAX_SKIPPED_TRANSACTIONS - skipped,
 					);
-					continue
+					continue;
 				} else if now < soft_deadline {
 					debug!(
 						target: LOG_TARGET,
@@ -507,13 +509,13 @@ where
 					 but we still have time before the soft deadline, so \
 					 we will try a bit more."
 					);
-					continue
+					continue;
 				} else {
 					debug!(
 						target: LOG_TARGET,
 						"Reached block size limit, proceeding with proposing."
 					);
-					break EndProposingReason::HitBlockSizeLimit
+					break EndProposingReason::HitBlockSizeLimit;
 				}
 			}
 
@@ -713,8 +715,17 @@ fn skip_shielded_txs() -> bool {
 mod tests {
 	use super::*;
 
+	use chacha20poly1305::{
+		aead::{Aead, Payload},
+		KeyInit, XChaCha20Poly1305, XNonce,
+	};
 	use futures::executor::block_on;
+	use ml_kem::{
+		kem::{Decapsulate, DecapsulationKey, EncapsulationKey},
+		Ciphertext, EncodedSizeUser, KemCore, MlKem768, MlKem768Params,
+	};
 	use parking_lot::Mutex;
+	use rand::rngs::OsRng;
 	use sc_client_api::{Backend, TrieCacheContext};
 	use sc_transaction_pool::BasicPool;
 	use sc_transaction_pool_api::{ChainEvent, MaintainedTransactionPool, TransactionSource};
@@ -722,6 +733,7 @@ mod tests {
 	use sp_blockchain::HeaderBackend;
 	use sp_consensus::{BlockOrigin, Environment, Proposer};
 	use sp_runtime::{generic::BlockId, traits::NumberFor, Perbill};
+	use stp_shield::{Result as TraitResult, ShieldKeystore};
 	use substrate_test_runtime_client::{
 		prelude::*,
 		runtime::{Block as TestBlock, Extrinsic, ExtrinsicBuilder, Transfer},
@@ -765,6 +777,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
+		let shield_keystore = Arc::new(TestShieldKeystore::new());
 
 		let hashof0 = client.info().genesis_hash;
 		block_on(txpool.submit_at(hashof0, SOURCE, vec![extrinsic(0), extrinsic(1)])).unwrap();
@@ -775,8 +788,14 @@ mod tests {
 			)),
 		);
 
-		let mut proposer_factory =
-			ProposerFactory::new(spawner.clone(), client.clone(), txpool.clone(), None, None);
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
 
 		let cell = Mutex::new((false, time::Instant::now()));
 		let proposer = proposer_factory.init_with_now(
@@ -785,7 +804,7 @@ mod tests {
 				let mut value = cell.lock();
 				if !value.0 {
 					value.0 = true;
-					return value.1
+					return value.1;
 				}
 				let old = value.1;
 				let new = old + time::Duration::from_secs(1);
@@ -818,9 +837,16 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
+		let shield_keystore = Arc::new(TestShieldKeystore::new());
 
-		let mut proposer_factory =
-			ProposerFactory::new(spawner.clone(), client.clone(), txpool.clone(), None, None);
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
 
 		let cell = Mutex::new((false, time::Instant::now()));
 		let proposer = proposer_factory.init_with_now(
@@ -829,7 +855,7 @@ mod tests {
 				let mut value = cell.lock();
 				if !value.0 {
 					value.0 = true;
-					return value.1
+					return value.1;
 				}
 				let new = value.1 + time::Duration::from_secs(160);
 				*value = (true, new);
@@ -855,6 +881,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
+		let shield_keystore = Arc::new(TestShieldKeystore::new());
 
 		let genesis_hash = client.info().best_hash;
 
@@ -868,8 +895,14 @@ mod tests {
 			)),
 		);
 
-		let mut proposer_factory =
-			ProposerFactory::new(spawner.clone(), client.clone(), txpool.clone(), None, None);
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
 
 		let proposer = proposer_factory.init_with_now(
 			&client.header(genesis_hash).unwrap().unwrap(),
@@ -911,6 +944,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
+		let shield_keystore = Arc::new(TestShieldKeystore::new());
 
 		let medium = |nonce| {
 			ExtrinsicBuilder::new_fill_block(Perbill::from_parts(MEDIUM))
@@ -928,8 +962,14 @@ mod tests {
 		))
 		.unwrap();
 
-		let mut proposer_factory =
-			ProposerFactory::new(spawner.clone(), client.clone(), txpool.clone(), None, None);
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
 		let mut propose_block = |client: &TestClient,
 		                         parent_number,
 		                         expected_block_extrinsics,
@@ -1019,6 +1059,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
+		let shield_keystore = Arc::new(TestShieldKeystore::new());
 		let genesis_hash = client.info().genesis_hash;
 		let genesis_header = client.expect_header(genesis_hash).expect("there should be header");
 
@@ -1035,20 +1076,26 @@ mod tests {
 		.chain((1..extrinsics_num as u64).map(extrinsic))
 		.collect::<Vec<_>>();
 
-		let block_limit = genesis_header.encoded_size() +
-			extrinsics
+		let block_limit = genesis_header.encoded_size()
+			+ extrinsics
 				.iter()
 				.take(extrinsics_num - 1)
 				.map(Encode::encoded_size)
-				.sum::<usize>() +
-			Vec::<Extrinsic>::new().encoded_size();
+				.sum::<usize>()
+			+ Vec::<Extrinsic>::new().encoded_size();
 
 		block_on(txpool.submit_at(genesis_hash, SOURCE, extrinsics.clone())).unwrap();
 
 		block_on(txpool.maintain(chain_event(genesis_header.clone())));
 
-		let mut proposer_factory =
-			ProposerFactory::new(spawner.clone(), client.clone(), txpool.clone(), None, None);
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore.clone(),
+		);
 
 		let proposer = block_on(proposer_factory.init(&genesis_header)).unwrap();
 
@@ -1082,6 +1129,7 @@ mod tests {
 			txpool.clone(),
 			None,
 			None,
+			shield_keystore,
 		);
 
 		let proposer = block_on(proposer_factory.init(&genesis_header)).unwrap();
@@ -1124,6 +1172,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
+		let shield_keystore = Arc::new(TestShieldKeystore::new());
 		let genesis_hash = client.info().genesis_hash;
 
 		let tiny = |nonce| {
@@ -1155,8 +1204,14 @@ mod tests {
 		)));
 		assert_eq!(txpool.ready().count(), MAX_SKIPPED_TRANSACTIONS * 3);
 
-		let mut proposer_factory =
-			ProposerFactory::new(spawner.clone(), client.clone(), txpool.clone(), None, None);
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
 
 		let cell = Mutex::new(time::Instant::now());
 		let proposer = proposer_factory.init_with_now(
@@ -1193,6 +1248,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
+		let shield_keystore = Arc::new(TestShieldKeystore::new());
 		let genesis_hash = client.info().genesis_hash;
 
 		let tiny = |who| {
@@ -1226,8 +1282,14 @@ mod tests {
 		)));
 		assert_eq!(txpool.ready().count(), MAX_SKIPPED_TRANSACTIONS * 2 + 4);
 
-		let mut proposer_factory =
-			ProposerFactory::new(spawner.clone(), client.clone(), txpool.clone(), None, None);
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
 
 		let deadline = time::Duration::from_secs(600);
 		let cell = Arc::new(Mutex::new((0, time::Instant::now())));
@@ -1266,5 +1328,49 @@ mod tests {
 			cell2.lock().0 > MAX_SKIPPED_TRANSACTIONS,
 			"Not enough calls to current time, which indicates the test might have ended because of deadline, not soft deadline"
 		);
+	}
+
+	struct TestShieldKeystore {
+		enc_key: EncapsulationKey<MlKem768Params>,
+		dec_key: DecapsulationKey<MlKem768Params>,
+	}
+
+	impl TestShieldKeystore {
+		fn new() -> Self {
+			let (dec_key, enc_key) = MlKem768::generate(&mut OsRng);
+			Self { enc_key, dec_key }
+		}
+	}
+
+	impl ShieldKeystore for TestShieldKeystore {
+		fn roll_for_next_slot(&self) -> TraitResult<()> {
+			Ok(())
+		}
+
+		fn next_public_key(&self) -> TraitResult<Vec<u8>> {
+			Ok(self.enc_key.as_bytes().to_vec())
+		}
+
+		fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> TraitResult<[u8; 32]> {
+			let ciphertext = Ciphertext::<MlKem768>::try_from(ciphertext).unwrap();
+			let shared_secret = self.dec_key.decapsulate(&ciphertext).unwrap();
+
+			Ok(shared_secret.into())
+		}
+
+		fn aead_decrypt(
+			&self,
+			key: [u8; 32],
+			nonce: [u8; 24],
+			msg: &[u8],
+			aad: &[u8],
+		) -> TraitResult<Vec<u8>> {
+			let aead = XChaCha20Poly1305::new((&key).into());
+			let nonce = XNonce::from_slice(&nonce);
+			let payload = Payload { msg, aad };
+			let decrypted = aead.decrypt(nonce, payload).unwrap();
+
+			Ok(decrypted)
+		}
 	}
 }

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -728,8 +728,8 @@ mod tests {
 	use substrate_test_runtime_client::{
 		prelude::*,
 		runtime::{
-			Block as TestBlock, Extrinsic, ExtrinsicBuilder, Transfer,
-			SHIELD_TEST_DECODE_KEY, SHIELD_TEST_UNSHIELD_KEY,
+			Block as TestBlock, Extrinsic, ExtrinsicBuilder, Transfer, SHIELD_TEST_DECODE_KEY,
+			SHIELD_TEST_UNSHIELD_KEY,
 		},
 		TestClientBuilder, TestClientBuilderExt,
 	};
@@ -1333,22 +1333,17 @@ mod tests {
 	) -> Arc<substrate_test_runtime_client::TestClient> {
 		let mut builder = TestClientBuilder::new();
 		if let Some(tx) = decode {
-			builder = builder
-				.add_extra_storage(SHIELD_TEST_DECODE_KEY.to_vec(), tx.encode());
+			builder = builder.add_extra_storage(SHIELD_TEST_DECODE_KEY.to_vec(), tx.encode());
 		}
 		if let Some(ext) = unshield {
-			builder = builder
-				.add_extra_storage(SHIELD_TEST_UNSHIELD_KEY.to_vec(), ext.encode());
+			builder = builder.add_extra_storage(SHIELD_TEST_UNSHIELD_KEY.to_vec(), ext.encode());
 		}
 		Arc::new(builder.build())
 	}
 
 	#[test]
 	fn shielded_tx_and_inner_tx_both_included_in_block() {
-		let client = shielded_test_client(
-			Some(mock_shielded_tx(100)),
-			Some(extrinsic(1)),
-		);
+		let client = shielded_test_client(Some(mock_shielded_tx(100)), Some(extrinsic(1)));
 		let spawner = sp_core::testing::TaskExecutor::new();
 		let txpool = Arc::from(BasicPool::new_full(
 			Default::default(),
@@ -1375,10 +1370,8 @@ mod tests {
 			shield_keystore,
 		);
 
-		let proposer = block_on(proposer_factory.init(
-			&client.expect_header(genesis_hash).unwrap(),
-		))
-		.unwrap();
+		let proposer =
+			block_on(proposer_factory.init(&client.expect_header(genesis_hash).unwrap())).unwrap();
 
 		let deadline = time::Duration::from_secs(9);
 		let block =
@@ -1393,10 +1386,7 @@ mod tests {
 	#[test]
 	fn shielded_tx_included_when_unshielding_fails() {
 		// Decode succeeds but unshielding fails (no unshield key in storage)
-		let client = shielded_test_client(
-			Some(mock_shielded_tx(100)),
-			None,
-		);
+		let client = shielded_test_client(Some(mock_shielded_tx(100)), None);
 		let spawner = sp_core::testing::TaskExecutor::new();
 		let txpool = Arc::from(BasicPool::new_full(
 			Default::default(),
@@ -1423,10 +1413,8 @@ mod tests {
 			shield_keystore,
 		);
 
-		let proposer = block_on(proposer_factory.init(
-			&client.expect_header(genesis_hash).unwrap(),
-		))
-		.unwrap();
+		let proposer =
+			block_on(proposer_factory.init(&client.expect_header(genesis_hash).unwrap())).unwrap();
 
 		let deadline = time::Duration::from_secs(9);
 		let block =
@@ -1440,10 +1428,7 @@ mod tests {
 
 	#[test]
 	fn should_skip_shielded_txs_when_env_var_is_set() {
-		let client = shielded_test_client(
-			Some(mock_shielded_tx(100)),
-			Some(extrinsic(2)),
-		);
+		let client = shielded_test_client(Some(mock_shielded_tx(100)), Some(extrinsic(2)));
 		let spawner = sp_core::testing::TaskExecutor::new();
 		let txpool = Arc::from(BasicPool::new_full(
 			Default::default(),
@@ -1456,8 +1441,7 @@ mod tests {
 		let genesis_hash = client.info().genesis_hash;
 
 		// Submit extrinsics to the pool
-		block_on(txpool.submit_at(genesis_hash, SOURCE, vec![extrinsic(0), extrinsic(1)]))
-			.unwrap();
+		block_on(txpool.submit_at(genesis_hash, SOURCE, vec![extrinsic(0), extrinsic(1)])).unwrap();
 		block_on(txpool.maintain(chain_event(
 			client.expect_header(genesis_hash).expect("there should be header"),
 		)));
@@ -1475,10 +1459,8 @@ mod tests {
 			shield_keystore,
 		);
 
-		let proposer = block_on(proposer_factory.init(
-			&client.expect_header(genesis_hash).unwrap(),
-		))
-		.unwrap();
+		let proposer =
+			block_on(proposer_factory.init(&client.expect_header(genesis_hash).unwrap())).unwrap();
 
 		let deadline = time::Duration::from_secs(9);
 		let block =
@@ -1496,10 +1478,7 @@ mod tests {
 	#[test]
 	fn block_size_accounts_for_unshielded_tx_size() {
 		let aead_ct_len = 10_000;
-		let client = shielded_test_client(
-			Some(mock_shielded_tx(aead_ct_len)),
-			Some(extrinsic(1)),
-		);
+		let client = shielded_test_client(Some(mock_shielded_tx(aead_ct_len)), Some(extrinsic(1)));
 		let spawner = sp_core::testing::TaskExecutor::new();
 		let txpool = Arc::from(BasicPool::new_full(
 			Default::default(),
@@ -1510,8 +1489,7 @@ mod tests {
 		));
 		let shield_keystore = Arc::new(TestShieldKeystore);
 		let genesis_hash = client.info().genesis_hash;
-		let genesis_header =
-			client.expect_header(genesis_hash).expect("there should be header");
+		let genesis_header = client.expect_header(genesis_hash).expect("there should be header");
 
 		let wrapper_tx = extrinsic(0);
 		let wrapper_encoded_size = wrapper_tx.encoded_size();

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -593,7 +593,7 @@ where
 			debug!(target: LOG_TARGET, "[{:?}] Failed to unshield transaction", shielded_tx_hash);
 			return Ok(());
 		};
-		trace!(target: LOG_TARGET, "[{:?}] Unshielded inner transaction: {:?}", shielded_tx_hash, unshielded_tx_data);
+		debug!(target: LOG_TARGET, "[{:?}] Unshielded inner transaction: {:?}", shielded_tx_hash, unshielded_tx_data);
 
 		match sc_block_builder::BlockBuilder::push(block_builder, unshielded_tx_data) {
 			Ok(()) => {

--- a/substrate/client/basic-authorship/src/lib.rs
+++ b/substrate/client/basic-authorship/src/lib.rs
@@ -29,6 +29,7 @@
 //! #     runtime::Transfer, Sr25519Keyring,
 //! #     DefaultTestClientBuilderExt, TestClientBuilderExt,
 //! # };
+//! # use stc_shield::MemoryShieldKeystore;
 //! # use sc_transaction_pool::{BasicPool, FullChainApi};
 //! # let client = Arc::new(substrate_test_runtime_client::new());
 //! # let spawner = sp_core::testing::TaskExecutor::new();
@@ -39,6 +40,7 @@
 //! #     spawner.clone(),
 //! #     client.clone(),
 //! # ));
+//! # let shield_keystore = Arc::new(MemoryShieldKeystore::new());
 //! // The first step is to create a `ProposerFactory`.
 //! let mut proposer_factory = ProposerFactory::new(
 //! 		spawner,
@@ -46,6 +48,7 @@
 //! 		txpool.clone(),
 //! 		None,
 //! 		None,
+//! 		shield_keystore,
 //! 	);
 //!
 //! // From this factory, we create a `Proposer`.

--- a/substrate/client/shield/Cargo.toml
+++ b/substrate/client/shield/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "stc-shield"
+description = "MEV Shield client implementation"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+log.workspace = true
+async-trait.workspace = true
+anyhow.workspace = true
+codec.workspace = true
+futures.workspace = true
+hex.workspace = true
+
+# Crypto
+rand.workspace = true
+chacha20poly1305 = { workspace = true, features = ["std"] }
+ml-kem = { workspace = true, features = ["zeroize"] }
+
+# Substrate
+sc-service.workspace = true
+sc-client-api.workspace = true
+sp-runtime.workspace = true
+sp-consensus.workspace = true
+sp-inherents.workspace = true
+
+# Subtensor
+stp-shield.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+std = [
+    "anyhow/std",
+    "chacha20poly1305/std",
+    "ml-kem/std",
+    "stp-shield/std",
+    "codec/std",
+    "futures/std",
+    "hex/std",
+    "log/std",
+    "rand/std",
+    "sp-runtime/std",
+    "sp-inherents/std",
+]

--- a/substrate/client/shield/Cargo.toml
+++ b/substrate/client/shield/Cargo.toml
@@ -14,7 +14,6 @@ hex.workspace = true
 
 # Crypto
 rand.workspace = true
-chacha20poly1305 = { workspace = true, features = ["std"] }
 ml-kem = { workspace = true, features = ["zeroize"] }
 
 # Substrate
@@ -34,7 +33,6 @@ workspace = true
 default = ["std"]
 std = [
     "anyhow/std",
-    "chacha20poly1305/std",
     "ml-kem/std",
     "stp-shield/std",
     "codec/std",

--- a/substrate/client/shield/README.md
+++ b/substrate/client/shield/README.md
@@ -6,14 +6,14 @@ MEV Shield client implementation for Subtensor. Provides the concrete pieces nee
 
 ## What it contains
 
-- **`MemoryShieldKeystore`** — in-memory implementation of the `ShieldKeystore` trait. Holds two ML-KEM-768 keypairs (current and next) and performs decapsulation and AEAD decryption.
+- **`MemoryShieldKeystore`** — in-memory implementation of the `ShieldKeystore` trait. Holds two ML-KEM-768 keypairs (current and next) and exposes the raw key bytes for the runtime to perform decryption in WASM.
 - **`spawn_key_rotation_on_own_import`** — spawns a background task that rotates keys each time the validator imports one of its own blocks.
-- **`InherentDataProvider`** — inserts the validator's next public key into each block as an inherent, so submitters can encrypt to it.
+- **`InherentDataProvider`** — inserts the validator's next encapsulation key into each block as an inherent, so submitters can encrypt to it.
 
 Requires `std`.
 
 ## How it fits in
 
-Wire `MemoryShieldKeystore` into the node service: register it as an externalities extension, spawn the key rotation task, and include `InherentDataProvider` in the block authoring pipeline.
+Wire `MemoryShieldKeystore` into the node service: pass it to the proposer factory and the inherent data provider, and spawn the key rotation task. The proposer reads `current_dec_key()` and passes it to the runtime API for in-WASM decryption.
 
 See [`stp-shield`](../../primitives/shield) for the trait definitions and types.

--- a/substrate/client/shield/README.md
+++ b/substrate/client/shield/README.md
@@ -1,0 +1,19 @@
+# stc-shield
+
+`stc` = **Subtensor Client**.
+
+MEV Shield client implementation for Subtensor. Provides the concrete pieces needed to run MEV Shield on the validator side.
+
+## What it contains
+
+- **`MemoryShieldKeystore`** — in-memory implementation of the `ShieldKeystore` trait. Holds two ML-KEM-768 keypairs (current and next) and performs decapsulation and AEAD decryption.
+- **`spawn_key_rotation_on_own_import`** — spawns a background task that rotates keys each time the validator imports one of its own blocks.
+- **`InherentDataProvider`** — inserts the validator's next public key into each block as an inherent, so submitters can encrypt to it.
+
+Requires `std`.
+
+## How it fits in
+
+Wire `MemoryShieldKeystore` into the node service: register it as an externalities extension, spawn the key rotation task, and include `InherentDataProvider` in the block authoring pipeline.
+
+See [`stp-shield`](../../primitives/shield) for the trait definitions and types.

--- a/substrate/client/shield/src/inherents.rs
+++ b/substrate/client/shield/src/inherents.rs
@@ -15,7 +15,7 @@ impl InherentDataProvider {
 #[async_trait::async_trait]
 impl sp_inherents::InherentDataProvider for InherentDataProvider {
     async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
-        let public_key = self.keystore.next_public_key().ok();
+        let public_key = self.keystore.next_enc_key().ok();
         let bounded = public_key.map(|pk| BoundedVec::truncate_from(pk));
         inherent_data.put_data::<InherentType>(INHERENT_IDENTIFIER, &bounded)
     }

--- a/substrate/client/shield/src/inherents.rs
+++ b/substrate/client/shield/src/inherents.rs
@@ -1,0 +1,30 @@
+use sp_inherents::{Error, InherentData, InherentIdentifier};
+use sp_runtime::BoundedVec;
+use stp_shield::{INHERENT_IDENTIFIER, InherentType, ShieldKeystorePtr};
+
+pub struct InherentDataProvider {
+    keystore: ShieldKeystorePtr,
+}
+
+impl InherentDataProvider {
+    pub fn new(keystore: ShieldKeystorePtr) -> Self {
+        Self { keystore }
+    }
+}
+
+#[async_trait::async_trait]
+impl sp_inherents::InherentDataProvider for InherentDataProvider {
+    async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
+        let public_key = self.keystore.next_public_key().ok();
+        let bounded = public_key.map(|pk| BoundedVec::truncate_from(pk));
+        inherent_data.put_data::<InherentType>(INHERENT_IDENTIFIER, &bounded)
+    }
+
+    async fn try_handle_error(
+        &self,
+        _: &InherentIdentifier,
+        _: &[u8],
+    ) -> Option<Result<(), Error>> {
+        None
+    }
+}

--- a/substrate/client/shield/src/key_rotation.rs
+++ b/substrate/client/shield/src/key_rotation.rs
@@ -1,0 +1,40 @@
+use futures::StreamExt;
+use sc_client_api::BlockchainEvents;
+use sc_service::SpawnTaskHandle;
+use sp_consensus::BlockOrigin;
+use sp_runtime::traits::{Block, Header};
+use std::sync::Arc;
+use stp_shield::ShieldKeystorePtr;
+
+pub fn spawn_key_rotation_on_own_import<B, C>(
+    task_spawner: &SpawnTaskHandle,
+    client: Arc<C>,
+    keystore: ShieldKeystorePtr,
+) where
+    B: Block,
+    C: BlockchainEvents<B> + Send + Sync + 'static,
+{
+    task_spawner.spawn("mev-shield-key-rotation", None, async move {
+        log::debug!(target: "mev-shield", "Key-rotation task started");
+        let mut import_stream = client.import_notification_stream();
+
+        while let Some(notif) = import_stream.next().await {
+            if notif.origin != BlockOrigin::Own {
+                continue;
+            }
+
+            if keystore.roll_for_next_slot().is_ok() {
+                log::debug!(
+                    target: "mev-shield",
+                    "Rotated shield key after importing own block #{}",
+                    notif.header.number()
+                );
+            } else {
+                log::warn!(
+                    target: "mev-shield",
+                    "Key rotation: failed to roll for next slot"
+                );
+            }
+        }
+    });
+}

--- a/substrate/client/shield/src/keystore.rs
+++ b/substrate/client/shield/src/keystore.rs
@@ -1,10 +1,6 @@
-use chacha20poly1305::{
-    KeyInit, XChaCha20Poly1305, XNonce,
-    aead::{Aead, Payload},
-};
 use ml_kem::{
-    Ciphertext, EncodedSizeUser, KemCore, MlKem768, MlKem768Params,
-    kem::{Decapsulate, DecapsulationKey, EncapsulationKey},
+    EncodedSizeUser, KemCore, MlKem768, MlKem768Params,
+    kem::{DecapsulationKey, EncapsulationKey},
 };
 use rand::rngs::OsRng;
 use std::sync::RwLock;
@@ -27,31 +23,18 @@ impl ShieldKeystore for MemoryShieldKeystore {
             .roll_for_next_slot()
     }
 
-    fn next_public_key(&self) -> TraitResult<Vec<u8>> {
+    fn next_enc_key(&self) -> TraitResult<Vec<u8>> {
         self.0
             .read()
             .map_err(|_| TraitError::Unavailable)?
-            .next_public_key()
+            .next_enc_key()
     }
 
-    fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> TraitResult<[u8; 32]> {
+    fn current_dec_key(&self) -> TraitResult<Vec<u8>> {
         self.0
             .read()
             .map_err(|_| TraitError::Unavailable)?
-            .mlkem768_decapsulate(ciphertext)
-    }
-
-    fn aead_decrypt(
-        &self,
-        key: [u8; 32],
-        nonce: [u8; 24],
-        msg: &[u8],
-        aad: &[u8],
-    ) -> TraitResult<Vec<u8>> {
-        self.0
-            .read()
-            .map_err(|_| TraitError::Unavailable)?
-            .aead_decrypt(key, nonce, msg, aad)
+            .current_dec_key()
     }
 }
 
@@ -74,39 +57,12 @@ impl ShieldKeystoreInner {
         Ok(())
     }
 
-    fn next_public_key(&self) -> TraitResult<Vec<u8>> {
+    fn next_enc_key(&self) -> TraitResult<Vec<u8>> {
         Ok(self.next_pair.enc_key.as_bytes().to_vec())
     }
 
-    fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> TraitResult<[u8; 32]> {
-        let ciphertext = Ciphertext::<MlKem768>::try_from(ciphertext)
-            .map_err(|e| TraitError::ValidationError(e.to_string()))?;
-        let shared_secret = self
-            .current_pair
-            .dec_key
-            .decapsulate(&ciphertext)
-            .map_err(|_| {
-                TraitError::Other("Failed to decapsulate ciphertext using ML-KEM 768".into())
-            })?;
-
-        Ok(shared_secret.into())
-    }
-
-    fn aead_decrypt(
-        &self,
-        key: [u8; 32],
-        nonce: [u8; 24],
-        msg: &[u8],
-        aad: &[u8],
-    ) -> TraitResult<Vec<u8>> {
-        let aead = XChaCha20Poly1305::new((&key).into());
-        let nonce = XNonce::from_slice(&nonce);
-        let payload = Payload { msg, aad };
-        let decrypted = aead
-            .decrypt(nonce, payload)
-            .map_err(|_| TraitError::Other("Failed to decrypt message using AEAD".into()))?;
-
-        Ok(decrypted)
+    fn current_dec_key(&self) -> TraitResult<Vec<u8>> {
+        Ok(self.current_pair.dec_key.as_bytes().to_vec())
     }
 }
 
@@ -127,193 +83,66 @@ impl ShieldKeyPair {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ml_kem::kem::Encapsulate;
+    use ml_kem::kem::{Decapsulate, Encapsulate};
     use stp_shield::ShieldKeystore;
 
-    const MLKEM768_PK_LEN: usize = 1184;
-    const MLKEM768_CT_LEN: usize = 1088;
+    const MLKEM768_ENC_KEY_LEN: usize = 1184;
+    const MLKEM768_DEC_KEY_LEN: usize = 2400;
 
     #[test]
-    fn next_public_key_returns_valid_mlkem768_key() {
+    fn next_enc_key_returns_valid_mlkem768_key() {
         let ks = MemoryShieldKeystore::new();
-        let pk = ks.next_public_key().unwrap();
-        assert_eq!(pk.len(), MLKEM768_PK_LEN);
+        let ek = ks.next_enc_key().unwrap();
+        assert_eq!(ek.len(), MLKEM768_ENC_KEY_LEN);
     }
 
     #[test]
-    fn next_public_key_is_stable_without_roll() {
+    fn next_enc_key_is_stable_without_roll() {
         let ks = MemoryShieldKeystore::new();
-        let pk1 = ks.next_public_key().unwrap();
-        let pk2 = ks.next_public_key().unwrap();
-        assert_eq!(pk1, pk2);
+        let ek1 = ks.next_enc_key().unwrap();
+        let ek2 = ks.next_enc_key().unwrap();
+        assert_eq!(ek1, ek2);
     }
 
     #[test]
-    fn roll_changes_next_public_key() {
+    fn roll_changes_next_enc_key() {
         let ks = MemoryShieldKeystore::new();
-        let before = ks.next_public_key().unwrap();
+        let before = ks.next_enc_key().unwrap();
         ks.roll_for_next_slot().unwrap();
-        let after = ks.next_public_key().unwrap();
+        let after = ks.next_enc_key().unwrap();
         assert_ne!(before, after);
     }
 
     #[test]
-    fn decapsulate_with_current_key_after_roll() {
+    fn current_dec_key_returns_valid_mlkem768_key() {
         let ks = MemoryShieldKeystore::new();
-
-        // The "next" public key is what will be announced in the inherent.
-        // After a roll, it becomes the "current" key used for decapsulation.
-        let pk_bytes = ks.next_public_key().unwrap();
-        let enc_key =
-            EncapsulationKey::<MlKem768Params>::from_bytes(pk_bytes.as_slice().try_into().unwrap());
-
-        let (ct, ss_sender) = enc_key.encapsulate(&mut OsRng).unwrap();
-
-        // Roll so that next → current.
         ks.roll_for_next_slot().unwrap();
-
-        // Decapsulate uses `current_pair`, which is now the old `next_pair`.
-        let ss_receiver = ks.mlkem768_decapsulate(ct.as_slice()).unwrap();
-        assert_eq!(ss_sender.as_slice(), &ss_receiver);
+        let dk = ks.current_dec_key().unwrap();
+        assert_eq!(dk.len(), MLKEM768_DEC_KEY_LEN);
+        // Verify the bytes can be parsed back into a valid DecapsulationKey.
+        DecapsulationKey::<MlKem768Params>::from_bytes(dk.as_slice().try_into().unwrap());
     }
 
     #[test]
-    fn decapsulate_fails_with_wrong_ciphertext() {
+    fn current_dec_key_matches_previous_enc_key() {
         let ks = MemoryShieldKeystore::new();
-        let garbage = vec![0u8; MLKEM768_CT_LEN];
-        // Decapsulation with garbage should still produce a result (ML-KEM implicit reject),
-        // but let's just verify it doesn't panic.
-        let _ = ks.mlkem768_decapsulate(&garbage);
-    }
-
-    #[test]
-    fn decapsulate_fails_with_wrong_length() {
-        let ks = MemoryShieldKeystore::new();
-        let short = vec![0u8; 32];
-        assert!(ks.mlkem768_decapsulate(&short).is_err());
-    }
-
-    #[test]
-    fn aead_encrypt_decrypt_roundtrip() {
-        let ks = MemoryShieldKeystore::new();
-        let key = [42u8; 32];
-        let nonce = [7u8; 24];
-        let plaintext = b"hello mev shield";
-        let aad = b"extra data";
-
-        // Encrypt with chacha20poly1305 directly.
-        let cipher = XChaCha20Poly1305::new((&key).into());
-        let ciphertext = cipher
-            .encrypt(
-                XNonce::from_slice(&nonce),
-                Payload {
-                    msg: plaintext,
-                    aad,
-                },
-            )
-            .unwrap();
-
-        // Decrypt via keystore.
-        let decrypted = ks.aead_decrypt(key, nonce, &ciphertext, aad).unwrap();
-        assert_eq!(decrypted, plaintext);
-    }
-
-    #[test]
-    fn aead_decrypt_fails_with_wrong_key() {
-        let ks = MemoryShieldKeystore::new();
-        let key = [42u8; 32];
-        let wrong_key = [99u8; 32];
-        let nonce = [7u8; 24];
-        let plaintext = b"secret";
-
-        let cipher = XChaCha20Poly1305::new((&key).into());
-        let ciphertext = cipher
-            .encrypt(
-                XNonce::from_slice(&nonce),
-                Payload {
-                    msg: plaintext.as_slice(),
-                    aad: &[],
-                },
-            )
-            .unwrap();
-
-        assert!(ks.aead_decrypt(wrong_key, nonce, &ciphertext, &[]).is_err());
-    }
-
-    #[test]
-    fn aead_decrypt_fails_with_wrong_aad() {
-        let ks = MemoryShieldKeystore::new();
-        let key = [42u8; 32];
-        let nonce = [7u8; 24];
-        let plaintext = b"secret";
-
-        let cipher = XChaCha20Poly1305::new((&key).into());
-        let ciphertext = cipher
-            .encrypt(
-                XNonce::from_slice(&nonce),
-                Payload {
-                    msg: plaintext.as_slice(),
-                    aad: b"correct aad",
-                },
-            )
-            .unwrap();
-
-        assert!(
-            ks.aead_decrypt(key, nonce, &ciphertext, b"wrong aad")
-                .is_err()
+        // Encapsulate to the "next" enc key.
+        let ek_bytes = ks.next_enc_key().unwrap();
+        let enc_key = EncapsulationKey::<MlKem768Params>::from_bytes(
+            ek_bytes.as_slice().try_into().unwrap(),
         );
-    }
+        let (kem_ct, shared_secret_enc) = enc_key.encapsulate(&mut OsRng).unwrap();
 
-    #[test]
-    fn full_encrypt_decrypt_roundtrip() {
-        // Simulates the full client → block author flow:
-        // 1. Client reads next_public_key, encapsulates, encrypts with AEAD
-        // 2. Author rolls, decapsulates with current key, decrypts AEAD
-        let ks = MemoryShieldKeystore::new();
-
-        // Client side: read the announced public key and encrypt.
-        let pk_bytes = ks.next_public_key().unwrap();
-        let enc_key =
-            EncapsulationKey::<MlKem768Params>::from_bytes(pk_bytes.as_slice().try_into().unwrap());
-        let (kem_ct, shared_secret) = enc_key.encapsulate(&mut OsRng).unwrap();
-
-        let nonce = [13u8; 24];
-        let plaintext = b"signed_extrinsic_bytes_here";
-        let cipher = XChaCha20Poly1305::new(shared_secret.as_slice().into());
-        let aead_ct = cipher
-            .encrypt(
-                XNonce::from_slice(&nonce),
-                Payload {
-                    msg: plaintext.as_slice(),
-                    aad: &[],
-                },
-            )
-            .unwrap();
-
-        // Author side: roll (next → current), then decrypt.
+        // Roll: next becomes current.
         ks.roll_for_next_slot().unwrap();
+        let dk_bytes = ks.current_dec_key().unwrap();
+        let dec_key = DecapsulationKey::<MlKem768Params>::from_bytes(
+            dk_bytes.as_slice().try_into().unwrap(),
+        );
 
-        let recovered_ss = ks.mlkem768_decapsulate(kem_ct.as_slice()).unwrap();
-        let decrypted = ks.aead_decrypt(recovered_ss, nonce, &aead_ct, &[]).unwrap();
-
-        assert_eq!(decrypted, plaintext);
-    }
-
-    #[test]
-    fn decapsulate_before_roll_uses_different_key() {
-        // Without rolling, decapsulate uses the initial `current_pair`,
-        // not the `next_pair` whose public key we encapsulated with.
-        let ks = MemoryShieldKeystore::new();
-
-        let pk_bytes = ks.next_public_key().unwrap();
-        let enc_key =
-            EncapsulationKey::<MlKem768Params>::from_bytes(pk_bytes.as_slice().try_into().unwrap());
-        let (kem_ct, ss_sender) = enc_key.encapsulate(&mut OsRng).unwrap();
-
-        // DO NOT roll — decapsulate uses initial current_pair, not next_pair.
-        let ss_receiver = ks.mlkem768_decapsulate(kem_ct.as_slice()).unwrap();
-
-        // Shared secrets should NOT match (different keypairs).
-        assert_ne!(ss_sender.as_slice(), &ss_receiver);
+        // Decapsulate with current dec key should yield the same shared secret.
+        let ct = ml_kem::Ciphertext::<MlKem768>::try_from(kem_ct.as_slice()).unwrap();
+        let shared_secret_dec = dec_key.decapsulate(&ct).unwrap();
+        assert_eq!(shared_secret_enc.as_slice(), shared_secret_dec.as_slice());
     }
 }

--- a/substrate/client/shield/src/keystore.rs
+++ b/substrate/client/shield/src/keystore.rs
@@ -1,0 +1,319 @@
+use chacha20poly1305::{
+    KeyInit, XChaCha20Poly1305, XNonce,
+    aead::{Aead, Payload},
+};
+use ml_kem::{
+    Ciphertext, EncodedSizeUser, KemCore, MlKem768, MlKem768Params,
+    kem::{Decapsulate, DecapsulationKey, EncapsulationKey},
+};
+use rand::rngs::OsRng;
+use std::sync::RwLock;
+use stp_shield::{Error as TraitError, Result as TraitResult, ShieldKeystore};
+
+/// An memory-based keystore for the MEV-Shield.
+pub struct MemoryShieldKeystore(RwLock<ShieldKeystoreInner>);
+
+impl MemoryShieldKeystore {
+    pub fn new() -> Self {
+        Self(RwLock::new(ShieldKeystoreInner::new()))
+    }
+}
+
+impl ShieldKeystore for MemoryShieldKeystore {
+    fn roll_for_next_slot(&self) -> TraitResult<()> {
+        self.0
+            .write()
+            .map_err(|_| TraitError::Unavailable)?
+            .roll_for_next_slot()
+    }
+
+    fn next_public_key(&self) -> TraitResult<Vec<u8>> {
+        self.0
+            .read()
+            .map_err(|_| TraitError::Unavailable)?
+            .next_public_key()
+    }
+
+    fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> TraitResult<[u8; 32]> {
+        self.0
+            .read()
+            .map_err(|_| TraitError::Unavailable)?
+            .mlkem768_decapsulate(ciphertext)
+    }
+
+    fn aead_decrypt(
+        &self,
+        key: [u8; 32],
+        nonce: [u8; 24],
+        msg: &[u8],
+        aad: &[u8],
+    ) -> TraitResult<Vec<u8>> {
+        self.0
+            .read()
+            .map_err(|_| TraitError::Unavailable)?
+            .aead_decrypt(key, nonce, msg, aad)
+    }
+}
+
+/// Holds the current/next ML‑KEM keypairs in-memory for a single author.
+pub struct ShieldKeystoreInner {
+    current_pair: ShieldKeyPair,
+    next_pair: ShieldKeyPair,
+}
+
+impl ShieldKeystoreInner {
+    fn new() -> Self {
+        Self {
+            current_pair: ShieldKeyPair::generate(),
+            next_pair: ShieldKeyPair::generate(),
+        }
+    }
+
+    fn roll_for_next_slot(&mut self) -> TraitResult<()> {
+        self.current_pair = std::mem::replace(&mut self.next_pair, ShieldKeyPair::generate());
+        Ok(())
+    }
+
+    fn next_public_key(&self) -> TraitResult<Vec<u8>> {
+        Ok(self.next_pair.enc_key.as_bytes().to_vec())
+    }
+
+    fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> TraitResult<[u8; 32]> {
+        let ciphertext = Ciphertext::<MlKem768>::try_from(ciphertext)
+            .map_err(|e| TraitError::ValidationError(e.to_string()))?;
+        let shared_secret = self
+            .current_pair
+            .dec_key
+            .decapsulate(&ciphertext)
+            .map_err(|_| {
+                TraitError::Other("Failed to decapsulate ciphertext using ML-KEM 768".into())
+            })?;
+
+        Ok(shared_secret.into())
+    }
+
+    fn aead_decrypt(
+        &self,
+        key: [u8; 32],
+        nonce: [u8; 24],
+        msg: &[u8],
+        aad: &[u8],
+    ) -> TraitResult<Vec<u8>> {
+        let aead = XChaCha20Poly1305::new((&key).into());
+        let nonce = XNonce::from_slice(&nonce);
+        let payload = Payload { msg, aad };
+        let decrypted = aead
+            .decrypt(nonce, payload)
+            .map_err(|_| TraitError::Other("Failed to decrypt message using AEAD".into()))?;
+
+        Ok(decrypted)
+    }
+}
+
+/// A pair of ML‑KEM‑768 decapsulation and encapsulation keys.
+#[derive(Debug, Clone)]
+struct ShieldKeyPair {
+    dec_key: DecapsulationKey<MlKem768Params>,
+    enc_key: EncapsulationKey<MlKem768Params>,
+}
+
+impl ShieldKeyPair {
+    fn generate() -> Self {
+        let (dec_key, enc_key) = MlKem768::generate(&mut OsRng);
+        Self { dec_key, enc_key }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ml_kem::kem::Encapsulate;
+    use stp_shield::ShieldKeystore;
+
+    const MLKEM768_PK_LEN: usize = 1184;
+    const MLKEM768_CT_LEN: usize = 1088;
+
+    #[test]
+    fn next_public_key_returns_valid_mlkem768_key() {
+        let ks = MemoryShieldKeystore::new();
+        let pk = ks.next_public_key().unwrap();
+        assert_eq!(pk.len(), MLKEM768_PK_LEN);
+    }
+
+    #[test]
+    fn next_public_key_is_stable_without_roll() {
+        let ks = MemoryShieldKeystore::new();
+        let pk1 = ks.next_public_key().unwrap();
+        let pk2 = ks.next_public_key().unwrap();
+        assert_eq!(pk1, pk2);
+    }
+
+    #[test]
+    fn roll_changes_next_public_key() {
+        let ks = MemoryShieldKeystore::new();
+        let before = ks.next_public_key().unwrap();
+        ks.roll_for_next_slot().unwrap();
+        let after = ks.next_public_key().unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn decapsulate_with_current_key_after_roll() {
+        let ks = MemoryShieldKeystore::new();
+
+        // The "next" public key is what will be announced in the inherent.
+        // After a roll, it becomes the "current" key used for decapsulation.
+        let pk_bytes = ks.next_public_key().unwrap();
+        let enc_key =
+            EncapsulationKey::<MlKem768Params>::from_bytes(pk_bytes.as_slice().try_into().unwrap());
+
+        let (ct, ss_sender) = enc_key.encapsulate(&mut OsRng).unwrap();
+
+        // Roll so that next → current.
+        ks.roll_for_next_slot().unwrap();
+
+        // Decapsulate uses `current_pair`, which is now the old `next_pair`.
+        let ss_receiver = ks.mlkem768_decapsulate(ct.as_slice()).unwrap();
+        assert_eq!(ss_sender.as_slice(), &ss_receiver);
+    }
+
+    #[test]
+    fn decapsulate_fails_with_wrong_ciphertext() {
+        let ks = MemoryShieldKeystore::new();
+        let garbage = vec![0u8; MLKEM768_CT_LEN];
+        // Decapsulation with garbage should still produce a result (ML-KEM implicit reject),
+        // but let's just verify it doesn't panic.
+        let _ = ks.mlkem768_decapsulate(&garbage);
+    }
+
+    #[test]
+    fn decapsulate_fails_with_wrong_length() {
+        let ks = MemoryShieldKeystore::new();
+        let short = vec![0u8; 32];
+        assert!(ks.mlkem768_decapsulate(&short).is_err());
+    }
+
+    #[test]
+    fn aead_encrypt_decrypt_roundtrip() {
+        let ks = MemoryShieldKeystore::new();
+        let key = [42u8; 32];
+        let nonce = [7u8; 24];
+        let plaintext = b"hello mev shield";
+        let aad = b"extra data";
+
+        // Encrypt with chacha20poly1305 directly.
+        let cipher = XChaCha20Poly1305::new((&key).into());
+        let ciphertext = cipher
+            .encrypt(
+                XNonce::from_slice(&nonce),
+                Payload {
+                    msg: plaintext,
+                    aad,
+                },
+            )
+            .unwrap();
+
+        // Decrypt via keystore.
+        let decrypted = ks.aead_decrypt(key, nonce, &ciphertext, aad).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn aead_decrypt_fails_with_wrong_key() {
+        let ks = MemoryShieldKeystore::new();
+        let key = [42u8; 32];
+        let wrong_key = [99u8; 32];
+        let nonce = [7u8; 24];
+        let plaintext = b"secret";
+
+        let cipher = XChaCha20Poly1305::new((&key).into());
+        let ciphertext = cipher
+            .encrypt(
+                XNonce::from_slice(&nonce),
+                Payload {
+                    msg: plaintext.as_slice(),
+                    aad: &[],
+                },
+            )
+            .unwrap();
+
+        assert!(ks.aead_decrypt(wrong_key, nonce, &ciphertext, &[]).is_err());
+    }
+
+    #[test]
+    fn aead_decrypt_fails_with_wrong_aad() {
+        let ks = MemoryShieldKeystore::new();
+        let key = [42u8; 32];
+        let nonce = [7u8; 24];
+        let plaintext = b"secret";
+
+        let cipher = XChaCha20Poly1305::new((&key).into());
+        let ciphertext = cipher
+            .encrypt(
+                XNonce::from_slice(&nonce),
+                Payload {
+                    msg: plaintext.as_slice(),
+                    aad: b"correct aad",
+                },
+            )
+            .unwrap();
+
+        assert!(
+            ks.aead_decrypt(key, nonce, &ciphertext, b"wrong aad")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn full_encrypt_decrypt_roundtrip() {
+        // Simulates the full client → block author flow:
+        // 1. Client reads next_public_key, encapsulates, encrypts with AEAD
+        // 2. Author rolls, decapsulates with current key, decrypts AEAD
+        let ks = MemoryShieldKeystore::new();
+
+        // Client side: read the announced public key and encrypt.
+        let pk_bytes = ks.next_public_key().unwrap();
+        let enc_key =
+            EncapsulationKey::<MlKem768Params>::from_bytes(pk_bytes.as_slice().try_into().unwrap());
+        let (kem_ct, shared_secret) = enc_key.encapsulate(&mut OsRng).unwrap();
+
+        let nonce = [13u8; 24];
+        let plaintext = b"signed_extrinsic_bytes_here";
+        let cipher = XChaCha20Poly1305::new(shared_secret.as_slice().into());
+        let aead_ct = cipher
+            .encrypt(
+                XNonce::from_slice(&nonce),
+                Payload {
+                    msg: plaintext.as_slice(),
+                    aad: &[],
+                },
+            )
+            .unwrap();
+
+        // Author side: roll (next → current), then decrypt.
+        ks.roll_for_next_slot().unwrap();
+
+        let recovered_ss = ks.mlkem768_decapsulate(kem_ct.as_slice()).unwrap();
+        let decrypted = ks.aead_decrypt(recovered_ss, nonce, &aead_ct, &[]).unwrap();
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn decapsulate_before_roll_uses_different_key() {
+        // Without rolling, decapsulate uses the initial `current_pair`,
+        // not the `next_pair` whose public key we encapsulated with.
+        let ks = MemoryShieldKeystore::new();
+
+        let pk_bytes = ks.next_public_key().unwrap();
+        let enc_key =
+            EncapsulationKey::<MlKem768Params>::from_bytes(pk_bytes.as_slice().try_into().unwrap());
+        let (kem_ct, ss_sender) = enc_key.encapsulate(&mut OsRng).unwrap();
+
+        // DO NOT roll — decapsulate uses initial current_pair, not next_pair.
+        let ss_receiver = ks.mlkem768_decapsulate(kem_ct.as_slice()).unwrap();
+
+        // Shared secrets should NOT match (different keypairs).
+        assert_ne!(ss_sender.as_slice(), &ss_receiver);
+    }
+}

--- a/substrate/client/shield/src/lib.rs
+++ b/substrate/client/shield/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod inherents;
+pub mod key_rotation;
+pub mod keystore;
+
+pub use inherents::*;
+pub use key_rotation::*;
+pub use keystore::*;

--- a/substrate/frame/aura/src/lib.rs
+++ b/substrate/frame/aura/src/lib.rs
@@ -230,7 +230,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Get the current slot from the pre-runtime digests.
-	fn current_slot_from_digests() -> Option<Slot> {
+	pub fn current_slot_from_digests() -> Option<Slot> {
 		let digest = frame_system::Pallet::<T>::digest();
 		let pre_runtime_digests = digest.logs.iter().filter_map(|d| d.as_pre_runtime());
 		for (id, mut data) in pre_runtime_digests {

--- a/substrate/primitives/runtime/src/generic/checked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/checked_extrinsic.rs
@@ -137,6 +137,10 @@ where
 				.dispatch_transaction(None.into(), self.function, info, len, extension_version),
 		}
 	}
+	
+	fn call(&self) -> &Self::Call {
+		&self.function
+	}
 }
 
 impl<AccountId, Call: Dispatchable, Extension: TransactionExtension<Call>>

--- a/substrate/primitives/runtime/src/traits/mod.rs
+++ b/substrate/primitives/runtime/src/traits/mod.rs
@@ -1815,6 +1815,9 @@ pub trait Applyable: Sized + Send + Sync {
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
 	) -> crate::ApplyExtrinsicResultWithInfo<PostDispatchInfoOf<Self::Call>>;
+	
+	/// Returns the call.
+	fn call(&self) -> &Self::Call;
 }
 
 /// A marker trait for something that knows the type of the runtime block.

--- a/substrate/primitives/shield/Cargo.toml
+++ b/substrate/primitives/shield/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 [dependencies]
 codec.workspace = true
 scale-info.workspace = true
-sp-externalities.workspace = true
 sp-api.workspace = true
 sp-runtime.workspace = true
 sp-inherents.workspace = true
@@ -21,7 +20,6 @@ default = ["std"]
 std = [
     "codec/std",
     "scale-info/std",
-    "sp-externalities/std",
     "sp-api/std",
     "sp-runtime/std",
     "sp-inherents/std",

--- a/substrate/primitives/shield/Cargo.toml
+++ b/substrate/primitives/shield/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "stp-shield"
+description = "MEV Shield primitives for Subtensor runtime"
+version = "0.1.0"
+edition.workspace = true
+
+
+[dependencies]
+codec.workspace = true
+scale-info.workspace = true
+sp-externalities.workspace = true
+sp-api.workspace = true
+sp-runtime.workspace = true
+sp-inherents.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "scale-info/std",
+    "sp-externalities/std",
+    "sp-api/std",
+    "sp-runtime/std",
+    "sp-inherents/std",
+]

--- a/substrate/primitives/shield/README.md
+++ b/substrate/primitives/shield/README.md
@@ -6,16 +6,15 @@ MEV Shield primitives for the Subtensor runtime. Defines the shared interface be
 
 ## What it contains
 
-- **`ShieldKeystore` trait** — interface for keystore operations: key rotation, public key retrieval, ML-KEM-768 decapsulation, and XChaCha20-Poly1305 decryption.
+- **`ShieldKeystore` trait** — interface for keystore operations: key rotation (`roll_for_next_slot`), encapsulation key retrieval (`next_enc_key`), and decapsulation key retrieval (`current_dec_key`).
 - **`ShieldedTransaction`** — structure representing an encrypted transaction (KEM ciphertext + AEAD ciphertext + nonce).
-- **`ShieldApi` runtime API** — allows the runtime to decode and decrypt shielded extrinsics.
-- **`ShieldKeystoreExt`** — registers the keystore as a Substrate externalities extension for use inside the runtime.
+- **`ShieldApi` runtime API** — allows the node to call into the runtime to decode and decrypt shielded extrinsics. The decapsulation key is passed as a parameter so no host functions are needed.
 - Common constants and type aliases (`ShieldPublicKey`, `InherentType`, `INHERENT_IDENTIFIER`).
 
 `no_std`-compatible.
 
 ## How it fits in
 
-Validators announce a public key via a block inherent. Submitters encrypt their transactions to that key. The validator decrypts them when building the block, preventing front-running.
+Validators announce an ML-KEM-768 encapsulation key via a block inherent. Submitters encrypt their transactions to that key. The validator passes the decapsulation key to the runtime API when building the block, and the runtime decrypts them in pure WASM — preventing front-running without requiring host functions.
 
 See [`stc-shield`](../../client/shield) for the client-side implementation.

--- a/substrate/primitives/shield/README.md
+++ b/substrate/primitives/shield/README.md
@@ -1,0 +1,21 @@
+# stp-shield
+
+`stp` = **Subtensor Primitive**.
+
+MEV Shield primitives for the Subtensor runtime. Defines the shared interface between the runtime and the client for transaction privacy via encryption.
+
+## What it contains
+
+- **`ShieldKeystore` trait** — interface for keystore operations: key rotation, public key retrieval, ML-KEM-768 decapsulation, and XChaCha20-Poly1305 decryption.
+- **`ShieldedTransaction`** — structure representing an encrypted transaction (KEM ciphertext + AEAD ciphertext + nonce).
+- **`ShieldApi` runtime API** — allows the runtime to decode and decrypt shielded extrinsics.
+- **`ShieldKeystoreExt`** — registers the keystore as a Substrate externalities extension for use inside the runtime.
+- Common constants and type aliases (`ShieldPublicKey`, `InherentType`, `INHERENT_IDENTIFIER`).
+
+`no_std`-compatible.
+
+## How it fits in
+
+Validators announce a public key via a block inherent. Submitters encrypt their transactions to that key. The validator decrypts them when building the block, preventing front-running.
+
+See [`stc-shield`](../../client/shield) for the client-side implementation.

--- a/substrate/primitives/shield/src/keystore.rs
+++ b/substrate/primitives/shield/src/keystore.rs
@@ -1,0 +1,88 @@
+//! MEV Shield Keystore traits
+
+extern crate alloc;
+
+use codec::{Decode, Encode};
+
+use alloc::{string::String, sync::Arc, vec::Vec};
+
+#[derive(Debug, Encode, Decode)]
+pub enum Error {
+    /// Keystore unavailable
+    Unavailable,
+    /// Validation error
+    ValidationError(String),
+    /// Other error
+    Other(String),
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::Unavailable => write!(f, "Keystore unavailable"),
+            Error::ValidationError(e) => write!(f, "Validation error: {}", e),
+            Error::Other(e) => write!(f, "Other error: {}", e),
+        }
+    }
+}
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Something that generates, stores and provides access to secret keys
+/// and operations used by the MEV Shield.
+pub trait ShieldKeystore: Send + Sync {
+    /// Roll for the next slot and update the current/next keys.
+    fn roll_for_next_slot(&self) -> Result<()>;
+
+    /// Get the next public key.
+    fn next_public_key(&self) -> Result<Vec<u8>>;
+
+    /// Decapsulate a ciphertext using the ML-KEM-768 algorithm.
+    fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> Result<[u8; 32]>;
+
+    /// Decrypt a ciphertext using the XChaCha20-Poly1305 AEAD scheme.
+    fn aead_decrypt(
+        &self,
+        key: [u8; 32],
+        nonce: [u8; 24],
+        msg: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>>;
+}
+
+impl<T: ShieldKeystore + 'static> ShieldKeystore for Arc<T> {
+    fn roll_for_next_slot(&self) -> Result<()> {
+        (**self).roll_for_next_slot()
+    }
+
+    fn next_public_key(&self) -> Result<Vec<u8>> {
+        (**self).next_public_key()
+    }
+
+    fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> Result<[u8; 32]> {
+        (**self).mlkem768_decapsulate(ciphertext)
+    }
+
+    fn aead_decrypt(
+        &self,
+        key: [u8; 32],
+        nonce: [u8; 24],
+        msg: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>> {
+        (**self).aead_decrypt(key, nonce, msg, aad)
+    }
+}
+
+pub type ShieldKeystorePtr = Arc<dyn ShieldKeystore>;
+
+sp_externalities::decl_extension! {
+    /// The shield keystore extension to register/retrieve from the externalities.
+    pub struct ShieldKeystoreExt(ShieldKeystorePtr);
+}
+
+impl ShieldKeystoreExt {
+    pub fn from(keystore: ShieldKeystorePtr) -> Self {
+        Self(keystore)
+    }
+}

--- a/substrate/primitives/shield/src/keystore.rs
+++ b/substrate/primitives/shield/src/keystore.rs
@@ -34,20 +34,11 @@ pub trait ShieldKeystore: Send + Sync {
     /// Roll for the next slot and update the current/next keys.
     fn roll_for_next_slot(&self) -> Result<()>;
 
-    /// Get the next public key.
-    fn next_public_key(&self) -> Result<Vec<u8>>;
+    /// Get the next ML-KEM-768 encapsulation (public) key bytes.
+    fn next_enc_key(&self) -> Result<Vec<u8>>;
 
-    /// Decapsulate a ciphertext using the ML-KEM-768 algorithm.
-    fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> Result<[u8; 32]>;
-
-    /// Decrypt a ciphertext using the XChaCha20-Poly1305 AEAD scheme.
-    fn aead_decrypt(
-        &self,
-        key: [u8; 32],
-        nonce: [u8; 24],
-        msg: &[u8],
-        aad: &[u8],
-    ) -> Result<Vec<u8>>;
+    /// Get the current ML-KEM-768 decapsulation (private) key bytes.
+    fn current_dec_key(&self) -> Result<Vec<u8>>;
 }
 
 impl<T: ShieldKeystore + 'static> ShieldKeystore for Arc<T> {
@@ -55,34 +46,13 @@ impl<T: ShieldKeystore + 'static> ShieldKeystore for Arc<T> {
         (**self).roll_for_next_slot()
     }
 
-    fn next_public_key(&self) -> Result<Vec<u8>> {
-        (**self).next_public_key()
+    fn next_enc_key(&self) -> Result<Vec<u8>> {
+        (**self).next_enc_key()
     }
 
-    fn mlkem768_decapsulate(&self, ciphertext: &[u8]) -> Result<[u8; 32]> {
-        (**self).mlkem768_decapsulate(ciphertext)
-    }
-
-    fn aead_decrypt(
-        &self,
-        key: [u8; 32],
-        nonce: [u8; 24],
-        msg: &[u8],
-        aad: &[u8],
-    ) -> Result<Vec<u8>> {
-        (**self).aead_decrypt(key, nonce, msg, aad)
+    fn current_dec_key(&self) -> Result<Vec<u8>> {
+        (**self).current_dec_key()
     }
 }
 
 pub type ShieldKeystorePtr = Arc<dyn ShieldKeystore>;
-
-sp_externalities::decl_extension! {
-    /// The shield keystore extension to register/retrieve from the externalities.
-    pub struct ShieldKeystoreExt(ShieldKeystorePtr);
-}
-
-impl ShieldKeystoreExt {
-    pub fn from(keystore: ShieldKeystorePtr) -> Self {
-        Self(keystore)
-    }
-}

--- a/substrate/primitives/shield/src/lib.rs
+++ b/substrate/primitives/shield/src/lib.rs
@@ -1,0 +1,24 @@
+//! MEV Shield primitives for Subtensor
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_inherents::InherentIdentifier;
+use sp_runtime::{BoundedVec, traits::ConstU32};
+
+mod keystore;
+mod runtime_api;
+mod shielded_tx;
+
+pub use keystore::*;
+pub use runtime_api::*;
+pub use shielded_tx::*;
+
+pub const LOG_TARGET: &str = "mev-shield";
+
+// The inherent identifier for the next MEV-Shield public key.
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"shieldpk";
+
+// The public key type for the MEV-Shield.
+pub type ShieldPublicKey = BoundedVec<u8, ConstU32<2048>>;
+
+// The inherent type for the MEV-Shield.
+pub type InherentType = Option<ShieldPublicKey>;

--- a/substrate/primitives/shield/src/lib.rs
+++ b/substrate/primitives/shield/src/lib.rs
@@ -1,6 +1,8 @@
 //! MEV Shield primitives for Subtensor
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 use sp_inherents::InherentIdentifier;
 use sp_runtime::{BoundedVec, traits::ConstU32};
 

--- a/substrate/primitives/shield/src/runtime_api.rs
+++ b/substrate/primitives/shield/src/runtime_api.rs
@@ -2,6 +2,7 @@
 
 extern crate alloc;
 
+use alloc::vec::Vec;
 use crate::ShieldedTransaction;
 use sp_runtime::traits::Block as BlockT;
 
@@ -10,6 +11,6 @@ type ExtrinsicOf<Block> = <Block as BlockT>::Extrinsic;
 sp_api::decl_runtime_apis! {
     pub trait ShieldApi {
         fn try_decode_shielded_tx(uxt: ExtrinsicOf<Block>) -> Option<ShieldedTransaction>;
-        fn try_unshield_tx(shielded_tx: ShieldedTransaction) -> Option<ExtrinsicOf<Block>>;
+        fn try_unshield_tx(dec_key_bytes: Vec<u8>, shielded_tx: ShieldedTransaction) -> Option<ExtrinsicOf<Block>>;
     }
 }

--- a/substrate/primitives/shield/src/runtime_api.rs
+++ b/substrate/primitives/shield/src/runtime_api.rs
@@ -1,0 +1,15 @@
+//! Runtime API definition for the MEV Shield.
+
+extern crate alloc;
+
+use crate::ShieldedTransaction;
+use sp_runtime::traits::Block as BlockT;
+
+type ExtrinsicOf<Block> = <Block as BlockT>::Extrinsic;
+
+sp_api::decl_runtime_apis! {
+    pub trait ShieldApi {
+        fn try_decode_shielded_tx(uxt: ExtrinsicOf<Block>) -> Option<ShieldedTransaction>;
+        fn try_unshield_tx(shielded_tx: ShieldedTransaction) -> Option<ExtrinsicOf<Block>>;
+    }
+}

--- a/substrate/primitives/shield/src/shielded_tx.rs
+++ b/substrate/primitives/shield/src/shielded_tx.rs
@@ -19,11 +19,8 @@ pub struct ShieldedTransaction {
 
 impl ShieldedTransaction {
     pub fn parse(ciphertext: &[u8]) -> Option<Self> {
-        let mut cursor: usize = 0;
-
-        let key_hash_end = cursor.checked_add(KEY_HASH_LEN)?;
-        let key_hash: [u8; KEY_HASH_LEN] = ciphertext.get(cursor..key_hash_end)?.try_into().ok()?;
-        cursor = key_hash_end;
+        let key_hash: [u8; KEY_HASH_LEN] = ciphertext.get(0..KEY_HASH_LEN)?.try_into().ok()?;
+        let mut cursor = KEY_HASH_LEN;
 
         let kem_ct_len_end = cursor.checked_add(2)?;
         let kem_ct_len = ciphertext

--- a/substrate/primitives/shield/src/shielded_tx.rs
+++ b/substrate/primitives/shield/src/shielded_tx.rs
@@ -1,0 +1,162 @@
+//! MEV Shielded Transaction
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+
+const KEY_HASH_LEN: usize = 16;
+const NONCE_LEN: usize = 24;
+
+#[derive(Debug, Clone, Encode, Decode, TypeInfo)]
+pub struct ShieldedTransaction {
+    pub key_hash: [u8; KEY_HASH_LEN],
+    pub kem_ct: Vec<u8>,
+    pub aead_ct: Vec<u8>,
+    pub nonce: [u8; NONCE_LEN],
+}
+
+impl ShieldedTransaction {
+    pub fn parse(ciphertext: &[u8]) -> Option<Self> {
+        let mut cursor: usize = 0;
+
+        let key_hash_end = cursor.checked_add(KEY_HASH_LEN)?;
+        let key_hash: [u8; KEY_HASH_LEN] = ciphertext.get(cursor..key_hash_end)?.try_into().ok()?;
+        cursor = key_hash_end;
+
+        let kem_ct_len_end = cursor.checked_add(2)?;
+        let kem_ct_len = ciphertext
+            .get(cursor..kem_ct_len_end)?
+            .try_into()
+            .map(u16::from_le_bytes)
+            .ok()?
+            .into();
+        cursor = kem_ct_len_end;
+
+        let kem_ct_end = cursor.checked_add(kem_ct_len)?;
+        let kem_ct = ciphertext.get(cursor..kem_ct_end)?.to_vec();
+        cursor = kem_ct_end;
+
+        let nonce_end = cursor.checked_add(NONCE_LEN)?;
+        let nonce = ciphertext.get(cursor..nonce_end)?.try_into().ok()?;
+        cursor = nonce_end;
+
+        let aead_ct = ciphertext.get(cursor..)?.to_vec();
+
+        Some(Self {
+            key_hash,
+            kem_ct,
+            aead_ct,
+            nonce,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_ciphertext(
+        key_hash: &[u8; KEY_HASH_LEN],
+        kem_ct: &[u8],
+        nonce: &[u8; 24],
+        aead_ct: &[u8],
+    ) -> Vec<u8> {
+        let kem_len = (kem_ct.len() as u16).to_le_bytes();
+        let mut buf = Vec::with_capacity(KEY_HASH_LEN + 2 + kem_ct.len() + 24 + aead_ct.len());
+        buf.extend_from_slice(key_hash);
+        buf.extend_from_slice(&kem_len);
+        buf.extend_from_slice(kem_ct);
+        buf.extend_from_slice(nonce);
+        buf.extend_from_slice(aead_ct);
+        buf
+    }
+
+    const DUMMY_KEM_CT: [u8; 1088] = [0xAA; 1088];
+    const DUMMY_NONCE: [u8; 24] = [0xBB; 24];
+    const DUMMY_KEY_HASH: [u8; KEY_HASH_LEN] = [0xCC; KEY_HASH_LEN];
+    const DUMMY_AEAD: [u8; 64] = [0xDD; 64];
+
+    fn valid_ciphertext() -> Vec<u8> {
+        build_ciphertext(&DUMMY_KEY_HASH, &DUMMY_KEM_CT, &DUMMY_NONCE, &DUMMY_AEAD)
+    }
+
+    #[test]
+    fn parse_valid_roundtrip() {
+        let ct = valid_ciphertext();
+        let tx = ShieldedTransaction::parse(&ct).expect("should parse");
+
+        assert_eq!(tx.key_hash, DUMMY_KEY_HASH);
+        assert_eq!(tx.kem_ct, DUMMY_KEM_CT);
+        assert_eq!(tx.nonce, DUMMY_NONCE);
+        assert_eq!(tx.aead_ct, DUMMY_AEAD);
+    }
+
+    #[test]
+    fn parse_empty_aead_ct() {
+        let ct = build_ciphertext(&DUMMY_KEY_HASH, &DUMMY_KEM_CT, &DUMMY_NONCE, &[]);
+        let tx = ShieldedTransaction::parse(&ct).expect("should parse with empty aead_ct");
+
+        assert!(tx.aead_ct.is_empty());
+        assert_eq!(tx.kem_ct, DUMMY_KEM_CT);
+    }
+
+    #[test]
+    fn parse_zero_length_kem_ct() {
+        let ct = build_ciphertext(&DUMMY_KEY_HASH, &[], &DUMMY_NONCE, &DUMMY_AEAD);
+        let tx = ShieldedTransaction::parse(&ct).expect("should parse with zero-length kem_ct");
+
+        assert!(tx.kem_ct.is_empty());
+        assert_eq!(tx.aead_ct, DUMMY_AEAD);
+    }
+
+    #[test]
+    fn parse_empty_returns_none() {
+        assert!(ShieldedTransaction::parse(&[]).is_none());
+    }
+
+    #[test]
+    fn parse_truncated_key_hash() {
+        let ct = [0u8; KEY_HASH_LEN - 1];
+        assert!(ShieldedTransaction::parse(&ct).is_none());
+    }
+
+    #[test]
+    fn parse_truncated_kem_len() {
+        // key_hash present but only 1 byte for kem_ct_len (needs 2).
+        let ct = [0u8; KEY_HASH_LEN + 1];
+        assert!(ShieldedTransaction::parse(&ct).is_none());
+    }
+
+    #[test]
+    fn parse_kem_ct_len_exceeds_remaining() {
+        // Claim 1088 bytes of kem_ct but only provide 10.
+        let mut ct = Vec::new();
+        ct.extend_from_slice(&DUMMY_KEY_HASH);
+        ct.extend_from_slice(&1088u16.to_le_bytes());
+        ct.extend_from_slice(&[0u8; 10]);
+        assert!(ShieldedTransaction::parse(&ct).is_none());
+    }
+
+    #[test]
+    fn parse_truncated_nonce() {
+        // key_hash + kem_len + kem_ct present, but nonce truncated.
+        let mut ct = Vec::new();
+        ct.extend_from_slice(&DUMMY_KEY_HASH);
+        ct.extend_from_slice(&4u16.to_le_bytes());
+        ct.extend_from_slice(&[0u8; 4]); // kem_ct
+        ct.extend_from_slice(&[0u8; 20]); // only 20 of 24 nonce bytes
+        assert!(ShieldedTransaction::parse(&ct).is_none());
+    }
+
+    #[test]
+    fn parse_small_kem_ct() {
+        let small_kem = [0x11; 4];
+        let ct = build_ciphertext(&DUMMY_KEY_HASH, &small_kem, &DUMMY_NONCE, &DUMMY_AEAD);
+        let tx = ShieldedTransaction::parse(&ct).expect("should parse");
+
+        assert_eq!(tx.kem_ct, small_kem);
+        assert_eq!(tx.aead_ct, DUMMY_AEAD);
+    }
+}

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -51,6 +51,8 @@ sp-trie.workspace = true
 sp-version.workspace = true
 trie-db = { workspace = true }
 
+stp-shield.workspace = true
+
 # 3rd party
 array-bytes = { optional = true, workspace = true, default-features = true }
 log = { workspace = true }

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -119,6 +119,7 @@ std = [
 	"substrate-wasm-builder",
 	"tracing/std",
 	"trie-db/std",
+	"stp-shield/std",
 ]
 
 # Special feature to disable logging

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -87,8 +87,6 @@ pub type AuraId = sp_consensus_aura::sr25519::AuthorityId;
 #[cfg(feature = "std")]
 pub use extrinsic::{ExtrinsicBuilder, Transfer};
 
-#[cfg(feature = "std")]
-use std::{cell::RefCell, thread_local};
 
 const LOG_TARGET: &str = "substrate-test-runtime";
 
@@ -512,11 +510,13 @@ pub const TEST_RUNTIME_BABE_EPOCH_CONFIGURATION: BabeEpochConfiguration = BabeEp
 	allowed_slots: AllowedSlots::PrimaryAndSecondaryPlainSlots,
 };
 
-#[cfg(feature = "std")]
-thread_local! {
-    pub static DECODE_SHIELDED_TX_RESULT: RefCell<Option<stp_shield::ShieldedTransaction>> = const { RefCell::new(None) };
-	pub static UNSHIELD_TX_RESULT: RefCell<Option<<Block as BlockT>::Extrinsic>> = const { RefCell::new(None) };
-}
+/// Well-known storage keys for injecting mock shielded transaction data in tests.
+/// We use storage instead of thread-locals because the test client executes runtime API calls
+/// via `WasmExecutor`, so thread-locals set on the host side are not accessible from Wasm.
+/// Write encoded `ShieldedTransaction` / `Extrinsic` to these keys via `add_extra_storage`
+/// on the test client builder.
+pub const SHIELD_TEST_DECODE_KEY: &[u8] = b"shield_test:decode_result";
+pub const SHIELD_TEST_UNSHIELD_KEY: &[u8] = b"shield_test:unshield_result";
 
 impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {
@@ -835,28 +835,14 @@ impl_runtime_apis! {
 	}
 	
 	impl stp_shield::ShieldApi<Block> for Runtime {
-		#[cfg(feature = "std")]
 		fn try_decode_shielded_tx(_uxt: <Block as BlockT>::Extrinsic) -> Option<stp_shield::ShieldedTransaction> {
-			DECODE_SHIELDED_TX_RESULT.with(|result| {
-				result.borrow().clone()
-			})
-		}
-		
-		#[cfg(feature = "std")]
-		fn try_unshield_tx(_shielded_tx: stp_shield::ShieldedTransaction) -> Option<<Block as BlockT>::Extrinsic> {
-			UNSHIELD_TX_RESULT.with(|result| {
-				result.borrow().clone()
-			})
-		}
-		
-		#[cfg(not(feature = "std"))]
-		fn try_decode_shielded_tx(_uxt: <Block as BlockT>::Extrinsic) -> Option<stp_shield::ShieldedTransaction> {
-			None
+			sp_io::storage::get(SHIELD_TEST_DECODE_KEY)
+				.and_then(|bytes| Decode::decode(&mut &bytes[..]).ok())
 		}
 
-		#[cfg(not(feature = "std"))]
 		fn try_unshield_tx(_shielded_tx: stp_shield::ShieldedTransaction) -> Option<<Block as BlockT>::Extrinsic> {
-			None
+			sp_io::storage::get(SHIELD_TEST_UNSHIELD_KEY)
+				.and_then(|bytes| Decode::decode(&mut &bytes[..]).ok())
 		}
 	}
 }

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -840,7 +840,7 @@ impl_runtime_apis! {
 				.and_then(|bytes| Decode::decode(&mut &bytes[..]).ok())
 		}
 
-		fn try_unshield_tx(_shielded_tx: stp_shield::ShieldedTransaction) -> Option<<Block as BlockT>::Extrinsic> {
+		fn try_unshield_tx(_dec_key_bytes: Vec<u8>, _shielded_tx: stp_shield::ShieldedTransaction) -> Option<<Block as BlockT>::Extrinsic> {
 			sp_io::storage::get(SHIELD_TEST_UNSHIELD_KEY)
 				.and_then(|bytes| Decode::decode(&mut &bytes[..]).ok())
 		}

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -87,6 +87,9 @@ pub type AuraId = sp_consensus_aura::sr25519::AuthorityId;
 #[cfg(feature = "std")]
 pub use extrinsic::{ExtrinsicBuilder, Transfer};
 
+#[cfg(feature = "std")]
+use std::{cell::RefCell, thread_local};
+
 const LOG_TARGET: &str = "substrate-test-runtime";
 
 // Include the WASM binary
@@ -509,6 +512,12 @@ pub const TEST_RUNTIME_BABE_EPOCH_CONFIGURATION: BabeEpochConfiguration = BabeEp
 	allowed_slots: AllowedSlots::PrimaryAndSecondaryPlainSlots,
 };
 
+#[cfg(feature = "std")]
+thread_local! {
+    pub static DECODE_SHIELDED_TX_RESULT: RefCell<Option<stp_shield::ShieldedTransaction>> = const { RefCell::new(None) };
+	pub static UNSHIELD_TX_RESULT: RefCell<Option<<Block as BlockT>::Extrinsic>> = const { RefCell::new(None) };
+}
+
 impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {
 		fn version() -> RuntimeVersion {
@@ -822,6 +831,32 @@ impl_runtime_apis! {
 
 		fn preset_names() -> Vec<PresetId> {
 			vec![PresetId::from("foobar"), PresetId::from("staging")]
+		}
+	}
+	
+	impl stp_shield::ShieldApi<Block> for Runtime {
+		#[cfg(feature = "std")]
+		fn try_decode_shielded_tx(_uxt: <Block as BlockT>::Extrinsic) -> Option<stp_shield::ShieldedTransaction> {
+			DECODE_SHIELDED_TX_RESULT.with(|result| {
+				result.borrow().clone()
+			})
+		}
+		
+		#[cfg(feature = "std")]
+		fn try_unshield_tx(_shielded_tx: stp_shield::ShieldedTransaction) -> Option<<Block as BlockT>::Extrinsic> {
+			UNSHIELD_TX_RESULT.with(|result| {
+				result.borrow().clone()
+			})
+		}
+		
+		#[cfg(not(feature = "std"))]
+		fn try_decode_shielded_tx(_uxt: <Block as BlockT>::Extrinsic) -> Option<stp_shield::ShieldedTransaction> {
+			None
+		}
+
+		#[cfg(not(feature = "std"))]
+		fn try_unshield_tx(_shielded_tx: stp_shield::ShieldedTransaction) -> Option<<Block as BlockT>::Extrinsic> {
+			None
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Companion PR to opentensor/subtensor#2477 - supersedes #6 

Adds MEV shield support to Substrate: shielded (encrypted) transaction handling in the block
proposer, along with the shared primitive and client crates (`stp-shield`, `stc-shield`) that were
moved here from subtensor to avoid a circular dependency between the two repos.

Users encrypt their extrinsics using ML-KEM-768 + XChaCha20-Poly1305 against the next block
author's public key. At block building time, the proposer passes the decapsulation key to the
runtime, which decrypts each shielded transaction entirely in WASM. Both the wrapper and the inner
extrinsic are then included in the block, keeping transaction contents hidden from the mempool.

## Changes

### `stp-shield` (new subtensor primitives crate)
Shared types used by both the runtime and the node side:
- `ShieldedTransaction` struct and wire-format parsing
- `ShieldKeystore` trait (simplified to key management only: `roll_for_next_slot`, `next_enc_key`,
  `current_dec_key`)
- `ShieldApi` runtime API definition (`try_decode_shielded_tx`, `try_unshield_tx`)
- Inherent identifier, `ShieldPublicKey` type, logging target

### `stc-shield` (new subtensor client crate)
Node-side shield logic:
- `MemoryShieldKeystore` — in-memory ML-KEM keystore implementation (key generation and storage
  only; no crypto operations — those now run in WASM)
- `InherentDataProvider` — provides the next encapsulation (public) key as an inherent
- `spawn_key_rotation_on_own_import` — rotates ML-KEM keypairs when the validator imports its own
  block

### `sc-basic-authorship` (block proposer)
- `ProposerFactory` / `Proposer` accept a `ShieldKeystorePtr` for key access
- Shielded transactions are detected via the `ShieldApi` runtime call
- The proposer reads the raw decapsulation key bytes from the keystore and passes them to the
  runtime's `try_unshield_tx`, which performs ML-KEM-768 decapsulation and XChaCha20-Poly1305 AEAD
  decryption entirely in WASM
- Both the wrapper and the decrypted inner extrinsic are pushed into the produced block
- Block size estimation accounts for wrapper + estimated inner transaction size
- Validators can opt out via `SUBSTRATE_SKIP_SHIELDED_TXS=1` — skipped transactions stay in the
  pool for gossip to other authors
- Refactored `report_exhausted_resources` helper shared between normal and unshielded tx paths

### `sp-runtime` (minor)
- Add `fn call()` to the `Applyable` trait (needed to inspect the call after signature check)

### `pallet-aura` (minor)
- Make `current_slot_from_digests` public for shield key rotation

### `substrate-test-runtime`
- Implement `ShieldApi` using storage keys (Wasm-compatible) for proposer tests

## Architecture

All cryptographic operations (ML-KEM-768 decapsulation, XChaCha20-Poly1305 decryption) run
**entirely in WASM** — no BLS12-381-style host function imports are needed. The node side is
responsible only for key generation, storage, and rotation; the raw decapsulation key bytes are
passed to the runtime API as a parameter.

| Operation | Runs in | Details |
|-----------|---------|---------|
| Key generation & storage | Node (`stc-shield`) | `MemoryShieldKeystore` with ML-KEM-768 |
| Key rotation | Node (background task) | Rolls keypairs on own block import |
| Public key announcement | WASM (inherent) | Pallet stores `CurrentKey` / `NextKey` |
| Shielded tx detection | WASM (runtime API) | `try_decode_shielded_tx` parses wrapper |
| ML-KEM decapsulation | WASM (runtime API) | `try_unshield_tx` — pure `ml-kem` crate |
| AEAD decryption | WASM (runtime API) | `try_unshield_tx` — pure `chacha20poly1305` crate |
| Block building orchestration | Node (proposer) | Calls runtime API, pushes both txs |

## Tests
<img width="1376" height="500" alt="Screenshot 2026-03-02 at 12 29 29 PM" src="https://github.com/user-attachments/assets/c24616ab-09f3-4c1e-8d9f-c5eab836e3b1" />
