### PR TITLE
Fix the timing issue for MEV transaction

### DIFF
--- a/substrate/client/basic-authorship/README.md
+++ b/substrate/client/basic-authorship/README.md
@@ -2,11 +2,12 @@ Basic implementation of block-authoring logic.
 
 ## MEV Shield integration
 
-When a `ShieldKeystorePtr` is provided to `ProposerFactory`, the proposer will handle shielded transactions during block authoring:
+When a `ShieldKeystorePtr` is provided to `ProposerFactory`, the proposer handles shielded transactions during block authoring:
 
-1. Each pending transaction is inspected via the `ShieldApi` runtime API to detect whether it is a shielded wrapper.
-2. Shielded transactions are decrypted on the spot using the keystore registered as a runtime extension. Block size accounting is adjusted to reflect the inner plaintext size rather than the ciphertext size.
-3. If the wrapper extrinsic applies successfully, the decrypted inner transaction is immediately pushed into the block as a second extrinsic.
+1. Each pending transaction is inspected via the `ShieldApi` runtime API (`try_decode_shielded_tx`) to detect whether it is a shielded wrapper.
+2. The proposer calls `is_shielded_using_current_key` (at the parent hash) with the transaction's `key_hash` to check whether the transaction is encrypted with the key this proposer can decrypt. Transactions encrypted with a different author's key are silently skipped — they stay in the pool for the correct author.
+3. Matching transactions are decrypted using the keystore's `current_dec_key`. Block size accounting is adjusted to reflect the inner plaintext size rather than the ciphertext size.
+4. If the wrapper extrinsic applies successfully, the decrypted inner transaction is immediately pushed into the block as a second extrinsic.
 
 Decryption happens only at block authoring time, never earlier. Setting the environment variable `SUBSTRATE_SKIP_SHIELDED_TXS=1` causes the proposer to skip all shielded transactions (leaving them in the pool for other authors).
 

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -467,11 +467,18 @@ where
 				.ok()
 				.flatten();
 
-			if skip_shielded_txs() && maybe_shielded_tx.is_some() {
-				debug!(target: LOG_TARGET, "Skipping shielded transaction");
-				// We don't report the transaction as invalid so it stay in the pool
-				// and may be gossiped to other block authors that allow them.
-				continue;
+			// Skip shielded txs we can't decrypt (wrong key or disabled via env var) without
+			// reporting them as invalid, they stay in the pool for the right block author to
+			// pick up.
+			if let Some(shielded_tx) = &maybe_shielded_tx {
+				let using_current_key = api
+					.is_shielded_using_current_key(self.parent_hash, &shielded_tx.key_hash)
+					.unwrap_or(false);
+
+				if skip_shielded_txs() || !using_current_key {
+					debug!(target: LOG_TARGET, "Skipping shielded transaction");
+					continue;
+				}
 			}
 
 			let pending_tx_data_size = if let Some(shielded_tx) = &maybe_shielded_tx {
@@ -739,8 +746,8 @@ mod tests {
 	use substrate_test_runtime_client::{
 		prelude::*,
 		runtime::{
-			Block as TestBlock, Extrinsic, ExtrinsicBuilder, Transfer, SHIELD_TEST_DECODE_KEY,
-			SHIELD_TEST_UNSHIELD_KEY,
+			Block as TestBlock, Extrinsic, ExtrinsicBuilder, Transfer, SHIELD_TEST_CURRENT_KEY,
+			SHIELD_TEST_DECODE_KEY, SHIELD_TEST_UNSHIELD_KEY,
 		},
 		TestClientBuilder, TestClientBuilderExt,
 	};
@@ -782,7 +789,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 
 		let hashof0 = client.info().genesis_hash;
 		block_on(txpool.submit_at(hashof0, SOURCE, vec![extrinsic(0), extrinsic(1)])).unwrap();
@@ -842,7 +849,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 
 		let mut proposer_factory = ProposerFactory::new(
 			spawner.clone(),
@@ -886,7 +893,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 
 		let genesis_hash = client.info().best_hash;
 
@@ -949,7 +956,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 
 		let medium = |nonce| {
 			ExtrinsicBuilder::new_fill_block(Perbill::from_parts(MEDIUM))
@@ -1064,7 +1071,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 		let genesis_hash = client.info().genesis_hash;
 		let genesis_header = client.expect_header(genesis_hash).expect("there should be header");
 
@@ -1177,7 +1184,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 		let genesis_hash = client.info().genesis_hash;
 
 		let tiny = |nonce| {
@@ -1253,7 +1260,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 		let genesis_hash = client.info().genesis_hash;
 
 		let tiny = |who| {
@@ -1341,6 +1348,7 @@ mod tests {
 	fn shielded_test_client(
 		decode: Option<ShieldedTransaction>,
 		unshield: Option<Extrinsic>,
+		is_current_key: bool,
 	) -> Arc<substrate_test_runtime_client::TestClient> {
 		let mut builder = TestClientBuilder::new();
 		if let Some(tx) = decode {
@@ -1349,12 +1357,14 @@ mod tests {
 		if let Some(ext) = unshield {
 			builder = builder.add_extra_storage(SHIELD_TEST_UNSHIELD_KEY.to_vec(), ext.encode());
 		}
+		builder =
+			builder.add_extra_storage(SHIELD_TEST_CURRENT_KEY.to_vec(), is_current_key.encode());
 		Arc::new(builder.build())
 	}
 
 	#[test]
 	fn shielded_tx_and_inner_tx_both_included_in_block() {
-		let client = shielded_test_client(Some(mock_shielded_tx(100)), Some(extrinsic(1)));
+		let client = shielded_test_client(Some(mock_shielded_tx(100)), Some(extrinsic(1)), true);
 		let spawner = sp_core::testing::TaskExecutor::new();
 		let txpool = Arc::from(BasicPool::new_full(
 			Default::default(),
@@ -1363,7 +1373,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 		let genesis_hash = client.info().genesis_hash;
 
 		// Submit one extrinsic (this becomes the wrapper)
@@ -1397,7 +1407,7 @@ mod tests {
 	#[test]
 	fn shielded_tx_included_when_unshielding_fails() {
 		// Decode succeeds but unshielding fails (no unshield key in storage)
-		let client = shielded_test_client(Some(mock_shielded_tx(100)), None);
+		let client = shielded_test_client(Some(mock_shielded_tx(100)), None, true);
 		let spawner = sp_core::testing::TaskExecutor::new();
 		let txpool = Arc::from(BasicPool::new_full(
 			Default::default(),
@@ -1406,7 +1416,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 		let genesis_hash = client.info().genesis_hash;
 
 		// Submit one extrinsic
@@ -1439,7 +1449,7 @@ mod tests {
 
 	#[test]
 	fn should_skip_shielded_txs_when_env_var_is_set() {
-		let client = shielded_test_client(Some(mock_shielded_tx(100)), Some(extrinsic(2)));
+		let client = shielded_test_client(Some(mock_shielded_tx(100)), Some(extrinsic(2)), true);
 		let spawner = sp_core::testing::TaskExecutor::new();
 		let txpool = Arc::from(BasicPool::new_full(
 			Default::default(),
@@ -1448,7 +1458,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 		let genesis_hash = client.info().genesis_hash;
 
 		// Submit extrinsics to the pool
@@ -1489,7 +1499,8 @@ mod tests {
 	#[test]
 	fn block_size_accounts_for_unshielded_tx_size() {
 		let aead_ct_len = 10_000;
-		let client = shielded_test_client(Some(mock_shielded_tx(aead_ct_len)), Some(extrinsic(1)));
+		let client =
+			shielded_test_client(Some(mock_shielded_tx(aead_ct_len)), Some(extrinsic(1)), true);
 		let spawner = sp_core::testing::TaskExecutor::new();
 		let txpool = Arc::from(BasicPool::new_full(
 			Default::default(),
@@ -1498,7 +1509,7 @@ mod tests {
 			spawner.clone(),
 			client.clone(),
 		));
-		let shield_keystore = Arc::new(TestShieldKeystore);
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
 		let genesis_hash = client.info().genesis_hash;
 		let genesis_header = client.expect_header(genesis_hash).expect("there should be header");
 
@@ -1551,9 +1562,109 @@ mod tests {
 		assert_eq!(block.extrinsics().len(), 0);
 	}
 
-	/// Minimal shield keystore stub, no actual decryption is performed in these tests
-	/// since the test runtime returns mock data from storage instead.
-	struct TestShieldKeystore;
+	#[test]
+	fn shielded_tx_skipped_when_not_using_current_key() {
+		// is_shielded_using_current_key returns false → tx is skipped entirely (stays in pool)
+		let client = shielded_test_client(Some(mock_shielded_tx(100)), Some(extrinsic(1)), false);
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let txpool = Arc::from(BasicPool::new_full(
+			Default::default(),
+			true.into(),
+			None,
+			spawner.clone(),
+			client.clone(),
+		));
+		let shield_keystore = Arc::new(TestShieldKeystore::default());
+		let genesis_hash = client.info().genesis_hash;
+
+		block_on(txpool.submit_at(genesis_hash, SOURCE, vec![extrinsic(0)])).unwrap();
+		block_on(txpool.maintain(chain_event(
+			client.expect_header(genesis_hash).expect("there should be header"),
+		)));
+		assert_eq!(txpool.ready().count(), 1);
+
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
+
+		let proposer =
+			block_on(proposer_factory.init(&client.expect_header(genesis_hash).unwrap())).unwrap();
+
+		let deadline = time::Duration::from_secs(9);
+		let block =
+			block_on(proposer.propose(Default::default(), Default::default(), deadline, None))
+				.map(|r| r.block)
+				.unwrap();
+
+		// Block should have 0 extrinsics: the shielded tx was skipped (wrong key)
+		assert_eq!(block.extrinsics().len(), 0);
+		// Transaction stays in the pool (not reported as invalid)
+		assert_eq!(txpool.ready().count(), 1);
+	}
+
+	#[test]
+	fn shielded_wrapper_included_when_dec_key_unavailable() {
+		// Keystore returns error for current_dec_key → wrapper is included, inner is skipped
+		let client = shielded_test_client(Some(mock_shielded_tx(100)), Some(extrinsic(1)), true);
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let txpool = Arc::from(BasicPool::new_full(
+			Default::default(),
+			true.into(),
+			None,
+			spawner.clone(),
+			client.clone(),
+		));
+		let shield_keystore = Arc::new(TestShieldKeystore::without_dec_key());
+		let genesis_hash = client.info().genesis_hash;
+
+		block_on(txpool.submit_at(genesis_hash, SOURCE, vec![extrinsic(0)])).unwrap();
+		block_on(txpool.maintain(chain_event(
+			client.expect_header(genesis_hash).expect("there should be header"),
+		)));
+
+		let mut proposer_factory = ProposerFactory::new(
+			spawner.clone(),
+			client.clone(),
+			txpool.clone(),
+			None,
+			None,
+			shield_keystore,
+		);
+
+		let proposer =
+			block_on(proposer_factory.init(&client.expect_header(genesis_hash).unwrap())).unwrap();
+
+		let deadline = time::Duration::from_secs(9);
+		let block =
+			block_on(proposer.propose(Default::default(), Default::default(), deadline, None))
+				.map(|r| r.block)
+				.unwrap();
+
+		// Block should contain 1 extrinsic: the wrapper was pushed, but inner was skipped
+		// because current_dec_key() returned an error
+		assert_eq!(block.extrinsics().len(), 1);
+	}
+
+	struct TestShieldKeystore {
+		dec_key_available: bool,
+	}
+
+	impl Default for TestShieldKeystore {
+		fn default() -> Self {
+			Self { dec_key_available: true }
+		}
+	}
+
+	impl TestShieldKeystore {
+		fn without_dec_key() -> Self {
+			Self { dec_key_available: false }
+		}
+	}
 
 	impl ShieldKeystore for TestShieldKeystore {
 		fn roll_for_next_slot(&self) -> TraitResult<()> {
@@ -1565,7 +1676,11 @@ mod tests {
 		}
 
 		fn current_dec_key(&self) -> TraitResult<Vec<u8>> {
-			Ok(Vec::new())
+			if self.dec_key_available {
+				Ok(Vec::new())
+			} else {
+				Err(stp_shield::Error::Other("no key available".into()))
+			}
 		}
 	}
 

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -350,9 +350,8 @@ where
 
 		let mode = block_builder.extrinsic_inclusion_mode();
 		let end_reason = match mode {
-			ExtrinsicInclusionMode::AllExtrinsics => {
-				self.apply_extrinsics(&mut block_builder, deadline, block_size_limit).await?
-			},
+			ExtrinsicInclusionMode::AllExtrinsics =>
+				self.apply_extrinsics(&mut block_builder, deadline, block_size_limit).await?,
 			ExtrinsicInclusionMode::OnlyInherents => EndProposingReason::TransactionForbidden,
 		};
 		let (block, storage_changes, proof) = block_builder.build()?.into_inner();
@@ -482,14 +481,14 @@ where
 			}
 
 			let pending_tx_data_size = if let Some(shielded_tx) = &maybe_shielded_tx {
-				// The ciphertext length for XChaCha20Poly1305 is the length of the plaintext + 16 bytes
-				// for the tag (source: https://www.rfc-editor.org/rfc/rfc8439#section-2.8) so we need
+				// The ciphertext length for XChaCha20Poly1305 is the length of the plaintext + 16
+				// bytes for the tag (source: https://www.rfc-editor.org/rfc/rfc8439#section-2.8) so we need
 				// to subtract it from the ciphertext length to get the plaintext length
 				const TAG_SIZE: usize = 16;
 				let unshielded_tx_size = shielded_tx.aead_ct.len().saturating_sub(TAG_SIZE);
 
-				// We will push the shielded tx wrapper and the unshielded inner tx to the block builder
-				// so we should account for both when estimating the block size
+				// We will push the shielded tx wrapper and the unshielded inner tx to the block
+				// builder so we should account for both when estimating the block size
 				pending_tx_data.encoded_size() + unshielded_tx_size
 			} else {
 				pending_tx_data.encoded_size()
@@ -1088,13 +1087,13 @@ mod tests {
 		.chain((1..extrinsics_num as u64).map(extrinsic))
 		.collect::<Vec<_>>();
 
-		let block_limit = genesis_header.encoded_size()
-			+ extrinsics
+		let block_limit = genesis_header.encoded_size() +
+			extrinsics
 				.iter()
 				.take(extrinsics_num - 1)
 				.map(Encode::encoded_size)
-				.sum::<usize>()
-			+ Vec::<Extrinsic>::new().encoded_size();
+				.sum::<usize>() +
+			Vec::<Extrinsic>::new().encoded_size();
 
 		block_on(txpool.submit_at(genesis_hash, SOURCE, extrinsics.clone())).unwrap();
 

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -468,7 +468,7 @@ where
 
 			// Skip shielded txs we can't decrypt (wrong key or disabled via env var) without
 			// reporting them as invalid, they stay in the pool for the right block author to
-			// pick up.
+			// pick them up.
 			if let Some(shielded_tx) = &maybe_shielded_tx {
 				let using_current_key = api
 					.is_shielded_using_current_key(self.parent_hash, &shielded_tx.key_hash)

--- a/substrate/client/shield/README.md
+++ b/substrate/client/shield/README.md
@@ -7,13 +7,13 @@ MEV Shield client implementation for Subtensor. Provides the concrete pieces nee
 ## What it contains
 
 - **`MemoryShieldKeystore`** — in-memory implementation of the `ShieldKeystore` trait. Holds two ML-KEM-768 keypairs (current and next) and exposes the raw key bytes for the runtime to perform decryption in WASM.
-- **`spawn_key_rotation_on_own_import`** — spawns a background task that rotates keys each time the validator imports one of its own blocks.
+- **`spawn_key_rotation_on_own_import`** — spawns a background task that rotates keys (`roll_for_next_slot`) each time the validator imports one of its own blocks. This promotes the `next` keypair to `current` and generates a fresh `next` keypair.
 - **`InherentDataProvider`** — inserts the validator's next encapsulation key into each block as an inherent, so submitters can encrypt to it.
 
 Requires `std`.
 
 ## How it fits in
 
-Wire `MemoryShieldKeystore` into the node service: pass it to the proposer factory and the inherent data provider, and spawn the key rotation task. The proposer reads `current_dec_key()` and passes it to the runtime API for in-WASM decryption.
+Wire `MemoryShieldKeystore` into the node service: pass it to the proposer factory and the inherent data provider, and spawn the key rotation task. During block authoring, the proposer uses `is_shielded_using_current_key` (via the runtime API) to check whether a shielded transaction's `key_hash` matches the key it can decrypt, then calls `current_dec_key()` and passes it to the runtime API for in-WASM decryption.
 
 See [`stp-shield`](../../primitives/shield) for the trait definitions and types.

--- a/substrate/client/shield/src/inherents.rs
+++ b/substrate/client/shield/src/inherents.rs
@@ -15,8 +15,8 @@ impl InherentDataProvider {
 #[async_trait::async_trait]
 impl sp_inherents::InherentDataProvider for InherentDataProvider {
     async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
-        let public_key = self.keystore.next_enc_key().ok();
-        let bounded = public_key.map(|pk| BoundedVec::truncate_from(pk));
+        let enc_key = self.keystore.next_enc_key().ok();
+        let bounded = enc_key.map(|k| BoundedVec::truncate_from(k));
         inherent_data.put_data::<InherentType>(INHERENT_IDENTIFIER, &bounded)
     }
 

--- a/substrate/primitives/shield/README.md
+++ b/substrate/primitives/shield/README.md
@@ -9,7 +9,7 @@ MEV Shield primitives for the Subtensor runtime. Defines the shared interface be
 - **`ShieldKeystore` trait** — interface for keystore operations: key rotation (`roll_for_next_slot`), encapsulation key retrieval (`next_enc_key`), and decapsulation key retrieval (`current_dec_key`).
 - **`ShieldedTransaction`** — structure representing an encrypted transaction (KEM ciphertext + AEAD ciphertext + nonce).
 - **`ShieldApi` runtime API** — allows the node to call into the runtime to decode and decrypt shielded extrinsics. The decapsulation key is passed as a parameter so no host functions are needed.
-- Common constants and type aliases (`ShieldPublicKey`, `InherentType`, `INHERENT_IDENTIFIER`).
+- Common constants and type aliases (`ShieldEncKey`, `MLKEM768_ENC_KEY_LEN`, `InherentType`, `INHERENT_IDENTIFIER`).
 
 `no_std`-compatible.
 

--- a/substrate/primitives/shield/README.md
+++ b/substrate/primitives/shield/README.md
@@ -7,11 +7,19 @@ MEV Shield primitives for the Subtensor runtime. Defines the shared interface be
 ## What it contains
 
 - **`ShieldKeystore` trait** — interface for keystore operations: key rotation (`roll_for_next_slot`), encapsulation key retrieval (`next_enc_key`), and decapsulation key retrieval (`current_dec_key`).
-- **`ShieldedTransaction`** — structure representing an encrypted transaction (KEM ciphertext + AEAD ciphertext + nonce).
-- **`ShieldApi` runtime API** — allows the node to call into the runtime to decode and decrypt shielded extrinsics. The decapsulation key is passed as a parameter so no host functions are needed.
+- **`ShieldedTransaction`** — structure representing an encrypted transaction (`key_hash` + KEM ciphertext + nonce + AEAD ciphertext).
+- **`ShieldApi` runtime API** — allows the node to call into the runtime to decode and decrypt shielded extrinsics. Includes `try_decode_shielded_tx` (parse a shielded wrapper) and `is_shielded_using_current_key` (check if a transaction's `key_hash` matches the key the proposer can decrypt). The decapsulation key is passed as a parameter so no host functions are needed.
 - Common constants and type aliases (`ShieldEncKey`, `MLKEM768_ENC_KEY_LEN`, `InherentType`, `INHERENT_IDENTIFIER`).
 
 `no_std`-compatible.
+
+## Key lifecycle
+
+The keystore holds two ML-KEM-768 keypairs: **current** and **next**.
+
+- `next_enc_key()` returns the encapsulation key of the `next` pair — this is announced via the block inherent so users can encrypt to it.
+- `current_dec_key()` returns the decapsulation key of the `current` pair — used by the proposer to decrypt shielded transactions in the block being built.
+- `roll_for_next_slot()` promotes `next` to `current` and generates a fresh `next` pair. Called when the validator imports one of its own blocks.
 
 ## How it fits in
 

--- a/substrate/primitives/shield/src/keystore.rs
+++ b/substrate/primitives/shield/src/keystore.rs
@@ -8,22 +8,22 @@ use alloc::{string::String, sync::Arc, vec::Vec};
 
 #[derive(Debug, Encode, Decode)]
 pub enum Error {
-    /// Keystore unavailable
-    Unavailable,
-    /// Validation error
-    ValidationError(String),
-    /// Other error
-    Other(String),
+	/// Keystore unavailable
+	Unavailable,
+	/// Validation error
+	ValidationError(String),
+	/// Other error
+	Other(String),
 }
 
 impl core::fmt::Display for Error {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Error::Unavailable => write!(f, "Keystore unavailable"),
-            Error::ValidationError(e) => write!(f, "Validation error: {}", e),
-            Error::Other(e) => write!(f, "Other error: {}", e),
-        }
-    }
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		match self {
+			Error::Unavailable => write!(f, "Keystore unavailable"),
+			Error::ValidationError(e) => write!(f, "Validation error: {}", e),
+			Error::Other(e) => write!(f, "Other error: {}", e),
+		}
+	}
 }
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -31,28 +31,28 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// Something that generates, stores and provides access to secret keys
 /// and operations used by the MEV Shield.
 pub trait ShieldKeystore: Send + Sync {
-    /// Roll for the next slot and update the current/next keys.
-    fn roll_for_next_slot(&self) -> Result<()>;
+	/// Roll for the next slot and update the current/next keys.
+	fn roll_for_next_slot(&self) -> Result<()>;
 
-    /// Get the next ML-KEM-768 encapsulation (public) key bytes.
-    fn next_enc_key(&self) -> Result<Vec<u8>>;
+	/// Get the next ML-KEM-768 encapsulation (public) key bytes.
+	fn next_enc_key(&self) -> Result<Vec<u8>>;
 
-    /// Get the current ML-KEM-768 decapsulation (private) key bytes.
-    fn current_dec_key(&self) -> Result<Vec<u8>>;
+	/// Get the current ML-KEM-768 decapsulation (private) key bytes.
+	fn current_dec_key(&self) -> Result<Vec<u8>>;
 }
 
 impl<T: ShieldKeystore + 'static> ShieldKeystore for Arc<T> {
-    fn roll_for_next_slot(&self) -> Result<()> {
-        (**self).roll_for_next_slot()
-    }
+	fn roll_for_next_slot(&self) -> Result<()> {
+		(**self).roll_for_next_slot()
+	}
 
-    fn next_enc_key(&self) -> Result<Vec<u8>> {
-        (**self).next_enc_key()
-    }
+	fn next_enc_key(&self) -> Result<Vec<u8>> {
+		(**self).next_enc_key()
+	}
 
-    fn current_dec_key(&self) -> Result<Vec<u8>> {
-        (**self).current_dec_key()
-    }
+	fn current_dec_key(&self) -> Result<Vec<u8>> {
+		(**self).current_dec_key()
+	}
 }
 
 pub type ShieldKeystorePtr = Arc<dyn ShieldKeystore>;

--- a/substrate/primitives/shield/src/lib.rs
+++ b/substrate/primitives/shield/src/lib.rs
@@ -16,11 +16,14 @@ pub use shielded_tx::*;
 
 pub const LOG_TARGET: &str = "mev-shield";
 
-// The inherent identifier for the next MEV-Shield public key.
+// The inherent identifier for the next MEV-Shield encapsulation key.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"shieldpk";
 
-// The public key type for the MEV-Shield.
-pub type ShieldPublicKey = BoundedVec<u8, ConstU32<2048>>;
+// ML-KEM-768 encapsulation key length in bytes.
+pub const MLKEM768_ENC_KEY_LEN: usize = 1184;
+
+// The encapsulation key type for the MEV-Shield.
+pub type ShieldEncKey = BoundedVec<u8, ConstU32<2048>>;
 
 // The inherent type for the MEV-Shield.
-pub type InherentType = Option<ShieldPublicKey>;
+pub type InherentType = Option<ShieldEncKey>;

--- a/substrate/primitives/shield/src/lib.rs
+++ b/substrate/primitives/shield/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 
 use sp_inherents::InherentIdentifier;
-use sp_runtime::{BoundedVec, traits::ConstU32};
+use sp_runtime::{traits::ConstU32, BoundedVec};
 
 mod keystore;
 mod runtime_api;

--- a/substrate/primitives/shield/src/runtime_api.rs
+++ b/substrate/primitives/shield/src/runtime_api.rs
@@ -2,15 +2,21 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
 use crate::ShieldedTransaction;
+use alloc::vec::Vec;
 use sp_runtime::traits::Block as BlockT;
 
 type ExtrinsicOf<Block> = <Block as BlockT>::Extrinsic;
 
 sp_api::decl_runtime_apis! {
-    pub trait ShieldApi {
-        fn try_decode_shielded_tx(uxt: ExtrinsicOf<Block>) -> Option<ShieldedTransaction>;
-        fn try_unshield_tx(dec_key_bytes: Vec<u8>, shielded_tx: ShieldedTransaction) -> Option<ExtrinsicOf<Block>>;
-    }
+	pub trait ShieldApi {
+		/// Try to decode a shielded transaction from an extrinsic.
+		fn try_decode_shielded_tx(uxt: ExtrinsicOf<Block>) -> Option<ShieldedTransaction>;
+
+		/// Check if a transaction is shielded using the current key.
+		fn is_shielded_using_current_key(key_hash: &[u8; 16]) -> bool;
+
+		/// Try to unshield a transaction using a decapsulation key.
+		fn try_unshield_tx(dec_key_bytes: Vec<u8>, shielded_tx: ShieldedTransaction) -> Option<ExtrinsicOf<Block>>;
+	}
 }

--- a/substrate/primitives/shield/src/shielded_tx.rs
+++ b/substrate/primitives/shield/src/shielded_tx.rs
@@ -11,149 +11,144 @@ const NONCE_LEN: usize = 24;
 
 #[derive(Debug, Clone, Encode, Decode, TypeInfo)]
 pub struct ShieldedTransaction {
-    pub key_hash: [u8; KEY_HASH_LEN],
-    pub kem_ct: Vec<u8>,
-    pub aead_ct: Vec<u8>,
-    pub nonce: [u8; NONCE_LEN],
+	pub key_hash: [u8; KEY_HASH_LEN],
+	pub kem_ct: Vec<u8>,
+	pub aead_ct: Vec<u8>,
+	pub nonce: [u8; NONCE_LEN],
 }
 
 impl ShieldedTransaction {
-    pub fn parse(ciphertext: &[u8]) -> Option<Self> {
-        let key_hash: [u8; KEY_HASH_LEN] = ciphertext.get(0..KEY_HASH_LEN)?.try_into().ok()?;
-        let mut cursor = KEY_HASH_LEN;
+	pub fn parse(ciphertext: &[u8]) -> Option<Self> {
+		let key_hash: [u8; KEY_HASH_LEN] = ciphertext.get(0..KEY_HASH_LEN)?.try_into().ok()?;
+		let mut cursor = KEY_HASH_LEN;
 
-        let kem_ct_len_end = cursor.checked_add(2)?;
-        let kem_ct_len = ciphertext
-            .get(cursor..kem_ct_len_end)?
-            .try_into()
-            .map(u16::from_le_bytes)
-            .ok()?
-            .into();
-        cursor = kem_ct_len_end;
+		let kem_ct_len_end = cursor.checked_add(2)?;
+		let kem_ct_len = ciphertext
+			.get(cursor..kem_ct_len_end)?
+			.try_into()
+			.map(u16::from_le_bytes)
+			.ok()?
+			.into();
+		cursor = kem_ct_len_end;
 
-        let kem_ct_end = cursor.checked_add(kem_ct_len)?;
-        let kem_ct = ciphertext.get(cursor..kem_ct_end)?.to_vec();
-        cursor = kem_ct_end;
+		let kem_ct_end = cursor.checked_add(kem_ct_len)?;
+		let kem_ct = ciphertext.get(cursor..kem_ct_end)?.to_vec();
+		cursor = kem_ct_end;
 
-        let nonce_end = cursor.checked_add(NONCE_LEN)?;
-        let nonce = ciphertext.get(cursor..nonce_end)?.try_into().ok()?;
-        cursor = nonce_end;
+		let nonce_end = cursor.checked_add(NONCE_LEN)?;
+		let nonce = ciphertext.get(cursor..nonce_end)?.try_into().ok()?;
+		cursor = nonce_end;
 
-        let aead_ct = ciphertext.get(cursor..)?.to_vec();
+		let aead_ct = ciphertext.get(cursor..)?.to_vec();
 
-        Some(Self {
-            key_hash,
-            kem_ct,
-            aead_ct,
-            nonce,
-        })
-    }
+		Some(Self { key_hash, kem_ct, aead_ct, nonce })
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    fn build_ciphertext(
-        key_hash: &[u8; KEY_HASH_LEN],
-        kem_ct: &[u8],
-        nonce: &[u8; 24],
-        aead_ct: &[u8],
-    ) -> Vec<u8> {
-        let kem_len = (kem_ct.len() as u16).to_le_bytes();
-        let mut buf = Vec::with_capacity(KEY_HASH_LEN + 2 + kem_ct.len() + 24 + aead_ct.len());
-        buf.extend_from_slice(key_hash);
-        buf.extend_from_slice(&kem_len);
-        buf.extend_from_slice(kem_ct);
-        buf.extend_from_slice(nonce);
-        buf.extend_from_slice(aead_ct);
-        buf
-    }
+	fn build_ciphertext(
+		key_hash: &[u8; KEY_HASH_LEN],
+		kem_ct: &[u8],
+		nonce: &[u8; 24],
+		aead_ct: &[u8],
+	) -> Vec<u8> {
+		let kem_len = (kem_ct.len() as u16).to_le_bytes();
+		let mut buf = Vec::with_capacity(KEY_HASH_LEN + 2 + kem_ct.len() + 24 + aead_ct.len());
+		buf.extend_from_slice(key_hash);
+		buf.extend_from_slice(&kem_len);
+		buf.extend_from_slice(kem_ct);
+		buf.extend_from_slice(nonce);
+		buf.extend_from_slice(aead_ct);
+		buf
+	}
 
-    const DUMMY_KEM_CT: [u8; 1088] = [0xAA; 1088];
-    const DUMMY_NONCE: [u8; 24] = [0xBB; 24];
-    const DUMMY_KEY_HASH: [u8; KEY_HASH_LEN] = [0xCC; KEY_HASH_LEN];
-    const DUMMY_AEAD: [u8; 64] = [0xDD; 64];
+	const DUMMY_KEM_CT: [u8; 1088] = [0xAA; 1088];
+	const DUMMY_NONCE: [u8; 24] = [0xBB; 24];
+	const DUMMY_KEY_HASH: [u8; KEY_HASH_LEN] = [0xCC; KEY_HASH_LEN];
+	const DUMMY_AEAD: [u8; 64] = [0xDD; 64];
 
-    fn valid_ciphertext() -> Vec<u8> {
-        build_ciphertext(&DUMMY_KEY_HASH, &DUMMY_KEM_CT, &DUMMY_NONCE, &DUMMY_AEAD)
-    }
+	fn valid_ciphertext() -> Vec<u8> {
+		build_ciphertext(&DUMMY_KEY_HASH, &DUMMY_KEM_CT, &DUMMY_NONCE, &DUMMY_AEAD)
+	}
 
-    #[test]
-    fn parse_valid_roundtrip() {
-        let ct = valid_ciphertext();
-        let tx = ShieldedTransaction::parse(&ct).expect("should parse");
+	#[test]
+	fn parse_valid_roundtrip() {
+		let ct = valid_ciphertext();
+		let tx = ShieldedTransaction::parse(&ct).expect("should parse");
 
-        assert_eq!(tx.key_hash, DUMMY_KEY_HASH);
-        assert_eq!(tx.kem_ct, DUMMY_KEM_CT);
-        assert_eq!(tx.nonce, DUMMY_NONCE);
-        assert_eq!(tx.aead_ct, DUMMY_AEAD);
-    }
+		assert_eq!(tx.key_hash, DUMMY_KEY_HASH);
+		assert_eq!(tx.kem_ct, DUMMY_KEM_CT);
+		assert_eq!(tx.nonce, DUMMY_NONCE);
+		assert_eq!(tx.aead_ct, DUMMY_AEAD);
+	}
 
-    #[test]
-    fn parse_empty_aead_ct() {
-        let ct = build_ciphertext(&DUMMY_KEY_HASH, &DUMMY_KEM_CT, &DUMMY_NONCE, &[]);
-        let tx = ShieldedTransaction::parse(&ct).expect("should parse with empty aead_ct");
+	#[test]
+	fn parse_empty_aead_ct() {
+		let ct = build_ciphertext(&DUMMY_KEY_HASH, &DUMMY_KEM_CT, &DUMMY_NONCE, &[]);
+		let tx = ShieldedTransaction::parse(&ct).expect("should parse with empty aead_ct");
 
-        assert!(tx.aead_ct.is_empty());
-        assert_eq!(tx.kem_ct, DUMMY_KEM_CT);
-    }
+		assert!(tx.aead_ct.is_empty());
+		assert_eq!(tx.kem_ct, DUMMY_KEM_CT);
+	}
 
-    #[test]
-    fn parse_zero_length_kem_ct() {
-        let ct = build_ciphertext(&DUMMY_KEY_HASH, &[], &DUMMY_NONCE, &DUMMY_AEAD);
-        let tx = ShieldedTransaction::parse(&ct).expect("should parse with zero-length kem_ct");
+	#[test]
+	fn parse_zero_length_kem_ct() {
+		let ct = build_ciphertext(&DUMMY_KEY_HASH, &[], &DUMMY_NONCE, &DUMMY_AEAD);
+		let tx = ShieldedTransaction::parse(&ct).expect("should parse with zero-length kem_ct");
 
-        assert!(tx.kem_ct.is_empty());
-        assert_eq!(tx.aead_ct, DUMMY_AEAD);
-    }
+		assert!(tx.kem_ct.is_empty());
+		assert_eq!(tx.aead_ct, DUMMY_AEAD);
+	}
 
-    #[test]
-    fn parse_empty_returns_none() {
-        assert!(ShieldedTransaction::parse(&[]).is_none());
-    }
+	#[test]
+	fn parse_empty_returns_none() {
+		assert!(ShieldedTransaction::parse(&[]).is_none());
+	}
 
-    #[test]
-    fn parse_truncated_key_hash() {
-        let ct = [0u8; KEY_HASH_LEN - 1];
-        assert!(ShieldedTransaction::parse(&ct).is_none());
-    }
+	#[test]
+	fn parse_truncated_key_hash() {
+		let ct = [0u8; KEY_HASH_LEN - 1];
+		assert!(ShieldedTransaction::parse(&ct).is_none());
+	}
 
-    #[test]
-    fn parse_truncated_kem_len() {
-        // key_hash present but only 1 byte for kem_ct_len (needs 2).
-        let ct = [0u8; KEY_HASH_LEN + 1];
-        assert!(ShieldedTransaction::parse(&ct).is_none());
-    }
+	#[test]
+	fn parse_truncated_kem_len() {
+		// key_hash present but only 1 byte for kem_ct_len (needs 2).
+		let ct = [0u8; KEY_HASH_LEN + 1];
+		assert!(ShieldedTransaction::parse(&ct).is_none());
+	}
 
-    #[test]
-    fn parse_kem_ct_len_exceeds_remaining() {
-        // Claim 1088 bytes of kem_ct but only provide 10.
-        let mut ct = Vec::new();
-        ct.extend_from_slice(&DUMMY_KEY_HASH);
-        ct.extend_from_slice(&1088u16.to_le_bytes());
-        ct.extend_from_slice(&[0u8; 10]);
-        assert!(ShieldedTransaction::parse(&ct).is_none());
-    }
+	#[test]
+	fn parse_kem_ct_len_exceeds_remaining() {
+		// Claim 1088 bytes of kem_ct but only provide 10.
+		let mut ct = Vec::new();
+		ct.extend_from_slice(&DUMMY_KEY_HASH);
+		ct.extend_from_slice(&1088u16.to_le_bytes());
+		ct.extend_from_slice(&[0u8; 10]);
+		assert!(ShieldedTransaction::parse(&ct).is_none());
+	}
 
-    #[test]
-    fn parse_truncated_nonce() {
-        // key_hash + kem_len + kem_ct present, but nonce truncated.
-        let mut ct = Vec::new();
-        ct.extend_from_slice(&DUMMY_KEY_HASH);
-        ct.extend_from_slice(&4u16.to_le_bytes());
-        ct.extend_from_slice(&[0u8; 4]); // kem_ct
-        ct.extend_from_slice(&[0u8; 20]); // only 20 of 24 nonce bytes
-        assert!(ShieldedTransaction::parse(&ct).is_none());
-    }
+	#[test]
+	fn parse_truncated_nonce() {
+		// key_hash + kem_len + kem_ct present, but nonce truncated.
+		let mut ct = Vec::new();
+		ct.extend_from_slice(&DUMMY_KEY_HASH);
+		ct.extend_from_slice(&4u16.to_le_bytes());
+		ct.extend_from_slice(&[0u8; 4]); // kem_ct
+		ct.extend_from_slice(&[0u8; 20]); // only 20 of 24 nonce bytes
+		assert!(ShieldedTransaction::parse(&ct).is_none());
+	}
 
-    #[test]
-    fn parse_small_kem_ct() {
-        let small_kem = [0x11; 4];
-        let ct = build_ciphertext(&DUMMY_KEY_HASH, &small_kem, &DUMMY_NONCE, &DUMMY_AEAD);
-        let tx = ShieldedTransaction::parse(&ct).expect("should parse");
+	#[test]
+	fn parse_small_kem_ct() {
+		let small_kem = [0x11; 4];
+		let ct = build_ciphertext(&DUMMY_KEY_HASH, &small_kem, &DUMMY_NONCE, &DUMMY_AEAD);
+		let tx = ShieldedTransaction::parse(&ct).expect("should parse");
 
-        assert_eq!(tx.kem_ct, small_kem);
-        assert_eq!(tx.aead_ct, DUMMY_AEAD);
-    }
+		assert_eq!(tx.kem_ct, small_kem);
+		assert_eq!(tx.aead_ct, DUMMY_AEAD);
+	}
 }

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -517,6 +517,9 @@ pub const TEST_RUNTIME_BABE_EPOCH_CONFIGURATION: BabeEpochConfiguration = BabeEp
 /// on the test client builder.
 pub const SHIELD_TEST_DECODE_KEY: &[u8] = b"shield_test:decode_result";
 pub const SHIELD_TEST_UNSHIELD_KEY: &[u8] = b"shield_test:unshield_result";
+/// When set to encoded `false`, `is_shielded_using_current_key` returns false.
+/// Absent or any other value → returns true (default behavior).
+pub const SHIELD_TEST_CURRENT_KEY: &[u8] = b"shield_test:is_current_key";
 
 impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {
@@ -838,6 +841,12 @@ impl_runtime_apis! {
 		fn try_decode_shielded_tx(_uxt: <Block as BlockT>::Extrinsic) -> Option<stp_shield::ShieldedTransaction> {
 			sp_io::storage::get(SHIELD_TEST_DECODE_KEY)
 				.and_then(|bytes| Decode::decode(&mut &bytes[..]).ok())
+		}
+		
+		fn is_shielded_using_current_key(_key_hash: &[u8; 16]) -> bool {
+			sp_io::storage::get(SHIELD_TEST_CURRENT_KEY)
+				.and_then(|bytes| Decode::decode(&mut &bytes[..]).ok())
+				.unwrap_or(true)
 		}
 
 		fn try_unshield_tx(_dec_key_bytes: Vec<u8>, _shielded_tx: stp_shield::ShieldedTransaction) -> Option<<Block as BlockT>::Extrinsic> {


### PR DESCRIPTION
## Move shielded tx key-matching from transaction extension to block proposer

Companion of opentensor/subtensor#2488

## Problem

Previously, `CheckShieldedTxValidity` rejected shielded transactions during block import (`InBlock`) if their key hash didn't match `CurrentKey` or `NextKey`. This caused transactions encrypted near a block boundary to be permanently rejected — by the time the block author tried to include them, the key had already rotated and the extension rejected them outright. The short `longevity: 3` was meant as a safeguard to evict stale transactions from the pool, but since it returned a constant value on every revalidation the countdown reset each block and transactions were never actually evicted.

## Changes

### New `is_shielded_using_current_key` runtime API

Added `is_shielded_using_current_key(key_hash)` to `ShieldApi`. Checks the transaction's key hash against `PendingKey` (the N+1 author's key staged at the parent hash) so the proposer can determine if a shielded tx is meant for the block being built.

### Proposer-side skip

The block proposer now calls `is_shielded_using_current_key` before attempting decryption. If the transaction was encrypted for a different author's key, the proposer silently skips it without reporting it as invalid — it stays in the pool for the correct block author to pick up.

### Test coverage

- Updated the test runtime to support configurable `is_shielded_using_current_key` behavior via storage.
- Added tests for the "wrong key" skip path and the "missing decapsulation key" fallback (wrapper included, inner skipped).


<img width="1275" height="273" alt="Screenshot 2026-03-05 at 7 35 12 PM" src="https://github.com/user-attachments/assets/e9e8f7f4-0a93-47b8-a412-ee63e307b265" />
