### PR TITLE
added get_module_indices on GetCallMetadata

### DIFF
--- a/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -32,6 +32,7 @@ pub fn expand_outer_dispatch(
 	let mut query_call_part_macros = Vec::new();
 	let mut pallet_names = Vec::new();
 	let mut pallet_attrs = Vec::new();
+	let mut pallet_indices = Vec::new();
 	let system_path = &system_pallet.path;
 
 	let pallets_with_call = pallet_decls.iter().filter(|decl| decl.exists_part("Call"));
@@ -51,6 +52,7 @@ pub fn expand_outer_dispatch(
 		variant_patterns.push(quote!(RuntimeCall::#name(call)));
 		pallet_names.push(name);
 		pallet_attrs.push(attr);
+		pallet_indices.push(index);
 		query_call_part_macros.push(quote! {
 			#path::__substrate_call_check::is_call_part_defined!(#name);
 		});
@@ -150,6 +152,12 @@ pub fn expand_outer_dispatch(
 				&[#(
 					#pallet_attrs
 					stringify!(#pallet_names),
+				)*]
+			}
+			
+			fn get_module_indices() -> &'static [u8] {
+				&[#(
+					#pallet_indices,
 				)*]
 			}
 

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -154,7 +154,7 @@ pub fn expand_outer_dispatch(
 					stringify!(#pallet_names),
 				)*]
 			}
-			
+
 			fn get_module_indices() -> &'static [u8] {
 				&[#(
 					#pallet_indices,

--- a/substrate/frame/support/src/traits/metadata.rs
+++ b/substrate/frame/support/src/traits/metadata.rs
@@ -122,8 +122,10 @@ pub trait GetCallIndex {
 
 /// Gets the metadata for the Call - function name and pallet name.
 pub trait GetCallMetadata {
-	/// Return all module names.
+	/// Return all module names in the same order as [`get_module_indices`].
 	fn get_module_names() -> &'static [&'static str];
+	/// Return all module indices in the same order as [`get_module_names`].
+	fn get_module_indices() -> &'static [u8];
 	/// Return all function names for the given `module`.
 	fn get_call_names(module: &str) -> &'static [&'static str];
 	/// Return a [`CallMetadata`], containing function and pallet name of the Call.

--- a/substrate/frame/support/test/tests/runtime.rs
+++ b/substrate/frame/support/test/tests/runtime.rs
@@ -719,24 +719,25 @@ fn get_call_names() {
 }
 
 #[test]
-fn get_module_names() {
+fn get_module_names_and_indices() {
 	use frame_support::traits::GetCallMetadata;
 	let module_names = RuntimeCall::get_module_names();
+	let module_indices = RuntimeCall::get_module_indices();
 	assert_eq!(
-		[
-			"Module1_6",
-			"Module1_7",
-			"Module1_4",
-			"Module1_8",
-			"Module1_9",
-			"System",
-			"Module1_1",
-			"Module2",
-			"Module1_2",
-			"NestedModule3",
-			"Module3",
+		vec![
+			("Module1_6", 1),
+			("Module1_7", 2),
+			("Module1_4", 3),
+			("Module1_8", 12),
+			("Module1_9", 13),
+			("System", 30),
+			("Module1_1", 31),
+			("Module2", 32),
+			("Module1_2", 33),
+			("NestedModule3", 34),
+			("Module3", 35),
 		],
-		module_names
+		module_names.iter().copied().zip(module_indices.iter().copied()).collect::<Vec<_>>()
 	);
 }
 

--- a/substrate/frame/support/test/tests/runtime.rs
+++ b/substrate/frame/support/test/tests/runtime.rs
@@ -737,7 +737,11 @@ fn get_module_names_and_indices() {
 			("NestedModule3", 34),
 			("Module3", 35),
 		],
-		module_names.iter().copied().zip(module_indices.iter().copied()).collect::<Vec<_>>()
+		module_names
+			.iter()
+			.copied()
+			.zip(module_indices.iter().copied())
+			.collect::<Vec<_>>()
 	);
 }
 

--- a/substrate/frame/support/test/tests/runtime_legacy_ordering.rs
+++ b/substrate/frame/support/test/tests/runtime_legacy_ordering.rs
@@ -719,24 +719,25 @@ fn get_call_names() {
 }
 
 #[test]
-fn get_module_names() {
+fn get_module_names_and_indices() {
 	use frame_support::traits::GetCallMetadata;
 	let module_names = RuntimeCall::get_module_names();
+	let module_indices = RuntimeCall::get_module_indices();
 	assert_eq!(
-		[
-			"System",
-			"Module1_1",
-			"Module2",
-			"Module1_2",
-			"NestedModule3",
-			"Module3",
-			"Module1_4",
-			"Module1_6",
-			"Module1_7",
-			"Module1_8",
-			"Module1_9",
+		vec![
+			("System", 30),
+			("Module1_1", 31),
+			("Module2", 32),
+			("Module1_2", 33),
+			("NestedModule3", 34),
+			("Module3", 35),
+			("Module1_4", 3),
+			("Module1_6", 1),
+			("Module1_7", 2),
+			("Module1_8", 12),
+			("Module1_9", 13),
 		],
-		module_names
+		module_names.iter().copied().zip(module_indices.iter().copied()).collect::<Vec<_>>()
 	);
 }
 

--- a/substrate/frame/support/test/tests/runtime_legacy_ordering.rs
+++ b/substrate/frame/support/test/tests/runtime_legacy_ordering.rs
@@ -737,7 +737,11 @@ fn get_module_names_and_indices() {
 			("Module1_8", 12),
 			("Module1_9", 13),
 		],
-		module_names.iter().copied().zip(module_indices.iter().copied()).collect::<Vec<_>>()
+		module_names
+			.iter()
+			.copied()
+			.zip(module_indices.iter().copied())
+			.collect::<Vec<_>>()
 	);
 }
 


### PR DESCRIPTION
### Description
Add a way to retrieve the module indices from the Call, in the same order as the names.