### PR TITLE
DispatchGuard to DispatchExtension

### DIFF
--- a/bridges/primitives/runtime/src/lib.rs
+++ b/bridges/primitives/runtime/src/lib.rs
@@ -34,9 +34,9 @@ use sp_runtime::{
 use sp_std::{fmt::Debug, ops::RangeInclusive, vec, vec::Vec};
 
 pub use chain::{
-	AccountIdOf, AccountPublicOf, BalanceOf, BlockNumberOf, Chain, EncodedOrDecodedCall, HashOf,
-	HasherOf, HeaderOf, NonceOf, Parachain, ParachainIdOf, SignatureOf, TransactionEraOf,
-	UnderlyingChainOf, UnderlyingChainProvider, __private,
+	__private, AccountIdOf, AccountPublicOf, BalanceOf, BlockNumberOf, Chain, EncodedOrDecodedCall,
+	HashOf, HasherOf, HeaderOf, NonceOf, Parachain, ParachainIdOf, SignatureOf, TransactionEraOf,
+	UnderlyingChainOf, UnderlyingChainProvider,
 };
 pub use frame_support::storage::storage_prefix as storage_value_final_key;
 use num_traits::{CheckedAdd, CheckedSub, One, SaturatingAdd, Zero};

--- a/bridges/primitives/runtime/src/lib.rs
+++ b/bridges/primitives/runtime/src/lib.rs
@@ -34,9 +34,9 @@ use sp_runtime::{
 use sp_std::{fmt::Debug, ops::RangeInclusive, vec, vec::Vec};
 
 pub use chain::{
-	__private, AccountIdOf, AccountPublicOf, BalanceOf, BlockNumberOf, Chain, EncodedOrDecodedCall,
-	HashOf, HasherOf, HeaderOf, NonceOf, Parachain, ParachainIdOf, SignatureOf, TransactionEraOf,
-	UnderlyingChainOf, UnderlyingChainProvider,
+	AccountIdOf, AccountPublicOf, BalanceOf, BlockNumberOf, Chain, EncodedOrDecodedCall, HashOf,
+	HasherOf, HeaderOf, NonceOf, Parachain, ParachainIdOf, SignatureOf, TransactionEraOf,
+	UnderlyingChainOf, UnderlyingChainProvider, __private,
 };
 pub use frame_support::storage::storage_prefix as storage_value_final_key;
 use num_traits::{CheckedAdd, CheckedSub, One, SaturatingAdd, Zero};

--- a/substrate/frame/support/procedural/examples/proc_main/main.rs
+++ b/substrate/frame/support/procedural/examples/proc_main/main.rs
@@ -59,6 +59,7 @@ pub mod frame_system {
 			#[inject_runtime_type]
 			type RuntimeTask = ();
 			type DbWeight = ();
+			type DispatchExtension = ();
 		}
 	}
 
@@ -76,12 +77,14 @@ pub mod frame_system {
 		#[pallet::no_default_bounds]
 		type RuntimeOrigin;
 		#[pallet::no_default_bounds]
-		type RuntimeCall;
+		type RuntimeCall: sp_runtime::traits::Dispatchable;
 		#[pallet::no_default_bounds]
 		type RuntimeTask: crate::traits::tasks::Task;
 		#[pallet::no_default_bounds]
 		type PalletInfo: crate::traits::PalletInfo;
 		type DbWeight: Get<crate::weights::RuntimeDbWeight>;
+		#[pallet::no_default_bounds]
+		type DispatchExtension: crate::traits::DispatchExtension<Self::RuntimeCall>;
 	}
 
 	#[pallet::error]

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -178,9 +178,9 @@ pub fn expand_outer_dispatch(
 					);
 				}
 
-				#system_path::Pallet::<#runtime>::check_dispatch_guard(&origin, &self)?;
-
-				#scrate::traits::UnfilteredDispatchable::dispatch_bypass_filter(self, origin)
+				<<#runtime as #system_path::Config>::DispatchExtension
+					as #scrate::traits::ExtendedDispatchable<RuntimeCall>
+				>::dispatch_with_extension(origin, self)
 			}
 		}
 		impl #scrate::traits::UnfilteredDispatchable for RuntimeCall {

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -110,12 +110,18 @@ pub fn expand_outer_dispatch(
 		}
 		impl #scrate::dispatch::GetDispatchInfo for RuntimeCall {
 			fn get_dispatch_info(&self) -> #scrate::dispatch::DispatchInfo {
-				match self {
+				let mut info = match self {
 					#(
 						#pallet_attrs
 						#variant_patterns => call.get_dispatch_info(),
 					)*
-				}
+				};
+				info.call_weight = info.call_weight.saturating_add(
+					<<#runtime as #system_path::Config>::DispatchExtension
+						as #scrate::dispatch::DispatchExtension<RuntimeCall>
+					>::weight(self)
+				);
+				info
 			}
 		}
 

--- a/substrate/frame/support/src/dispatch.rs
+++ b/substrate/frame/support/src/dispatch.rs
@@ -18,7 +18,7 @@
 //! Dispatch system. Contains a macro for defining runtime modules and
 //! generating values representing lazy module function calls.
 
-use crate::traits::UnfilteredDispatchable;
+pub use crate::traits::{DispatchExtension, ExtendedDispatchable, UnfilteredDispatchable};
 use codec::{Codec, Decode, DecodeWithMemTracking, Encode, EncodeLike, MaxEncodedLen};
 use core::fmt;
 use scale_info::TypeInfo;
@@ -705,22 +705,6 @@ impl<T> PaysFee<T> for (u64, Pays) {
 
 // END TODO
 
-/// A `DispatchGuard` is executed right before the `Call` is dispatched. It has access
-/// to read-only storage and any changes will be rolled back. Root origin will passthrough.
-///
-/// The trait is implemented for all tuples of up to 30 elements.
-pub trait DispatchGuard<Call: Dispatchable> {
-	fn check(origin: &Call::RuntimeOrigin, call: &Call) -> DispatchResultWithPostInfo;
-}
-
-#[impl_trait_for_tuples::impl_for_tuples(30)]
-impl<Call: Dispatchable> DispatchGuard<Call> for Tuple {
-	fn check(origin: &Call::RuntimeOrigin, call: &Call) -> DispatchResultWithPostInfo {
-		for_tuples!( #( Tuple::check(origin, call)?; )* );
-		Ok(().into())
-	}
-}
-
 #[cfg(test)]
 // Do not complain about unused `dispatch` and `dispatch_aux`.
 #[allow(dead_code)]
@@ -747,7 +731,7 @@ mod weight_tests {
 	pub mod frame_system {
 		use super::{frame_system, frame_system::pallet_prelude::*};
 		pub use crate::dispatch::RawOrigin;
-		use crate::pallet_prelude::*;
+		use crate::{pallet_prelude::*, traits::DispatchExtension};
 
 		#[pallet::pallet]
 		pub struct Pallet<T>(_);
@@ -760,10 +744,11 @@ mod weight_tests {
 			type Balance;
 			type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall>;
 			type RuntimeOrigin;
-			type RuntimeCall;
+			type RuntimeCall: sp_runtime::traits::Dispatchable;
 			type RuntimeTask;
 			type PalletInfo: crate::traits::PalletInfo;
 			type DbWeight: Get<crate::weights::RuntimeDbWeight>;
+			type DispatchExtension: DispatchExtension<Self::RuntimeCall>;
 		}
 
 		#[pallet::error]
@@ -883,6 +868,7 @@ mod weight_tests {
 		type RuntimeTask = RuntimeTask;
 		type DbWeight = DbWeight;
 		type PalletInfo = PalletInfo;
+		type DispatchExtension = ();
 	}
 
 	#[test]
@@ -1413,6 +1399,7 @@ mod extension_weight_tests {
 		type RuntimeTask = RuntimeTask;
 		type DbWeight = DbWeight;
 		type PalletInfo = PalletInfo;
+		type DispatchExtension = ();
 	}
 
 	parameter_types! {

--- a/substrate/frame/support/src/storage/generator/mod.rs
+++ b/substrate/frame/support/src/storage/generator/mod.rs
@@ -63,10 +63,11 @@ mod tests {
 			type AccountId;
 			type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall>;
 			type RuntimeOrigin;
-			type RuntimeCall;
+			type RuntimeCall: sp_runtime::traits::Dispatchable;
 			type RuntimeTask;
 			type PalletInfo: crate::traits::PalletInfo;
 			type DbWeight: Get<crate::weights::RuntimeDbWeight>;
+			type DispatchExtension: crate::traits::DispatchExtension<Self::RuntimeCall>;
 		}
 
 		#[pallet::origin]
@@ -143,6 +144,7 @@ mod tests {
 		type RuntimeTask = RuntimeTask;
 		type PalletInfo = PalletInfo;
 		type DbWeight = ();
+		type DispatchExtension = ();
 	}
 
 	pub fn key_before_prefix(mut prefix: Vec<u8>) -> Vec<u8> {

--- a/substrate/frame/support/src/tests/dispatch_extension.rs
+++ b/substrate/frame/support/src/tests/dispatch_extension.rs
@@ -1,0 +1,348 @@
+use crate::{
+	assert_noop, assert_ok,
+	dispatch::{DispatchExtension, DispatchResultWithPostInfo},
+	parameter_types,
+	traits::ExtendedDispatchable,
+};
+use sp_io::TestExternalities;
+use sp_runtime::{generic, traits::BlakeTwo256, BuildStorage, DispatchError};
+
+// -- Mock runtime ---------------------------------------------------------------
+
+#[crate::pallet(dev_mode)]
+mod frame_system {
+	#[allow(unused)]
+	use super::frame_system;
+	pub use crate::dispatch::RawOrigin;
+	use crate::{pallet_prelude::*, traits::DispatchExtension};
+	use pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	#[pallet::disable_frame_system_supertrait_check]
+	pub trait Config: 'static {
+		type Block: Parameter + sp_runtime::traits::Block;
+		type AccountId;
+		type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall>;
+		type RuntimeOrigin;
+		type RuntimeCall: sp_runtime::traits::Dispatchable;
+		type RuntimeTask;
+		type PalletInfo: crate::traits::PalletInfo;
+		type DbWeight: Get<crate::weights::RuntimeDbWeight>;
+		type DispatchExtension: DispatchExtension<Self::RuntimeCall>;
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		CallFiltered,
+	}
+
+	#[pallet::origin]
+	pub type Origin<T> = RawOrigin<<T as Config>::AccountId>;
+
+	pub mod pallet_prelude {
+		pub type OriginFor<T> = <T as super::Config>::RuntimeOrigin;
+
+		pub type HeaderFor<T> =
+			<<T as super::Config>::Block as sp_runtime::traits::HeaderProvider>::HeaderT;
+
+		pub type BlockNumberFor<T> = <HeaderFor<T> as sp_runtime::traits::Header>::Number;
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// A no-op call that accepts any origin.
+		#[pallet::call_index(0)]
+		#[pallet::weight(0)]
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			Ok(().into())
+		}
+
+		/// A call that always fails.
+		#[pallet::call_index(1)]
+		#[pallet::weight(0)]
+		pub fn always_fails(_origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			Err(sp_runtime::DispatchError::Other("call failed").into())
+		}
+	}
+}
+
+type Header = generic::Header<u32, BlakeTwo256>;
+type UncheckedExtrinsic = generic::UncheckedExtrinsic<u64, RuntimeCall, (), ()>;
+type Block = generic::Block<Header, UncheckedExtrinsic>;
+
+#[crate::runtime]
+mod runtime {
+	#[runtime::runtime]
+	#[runtime::derive(
+		RuntimeCall,
+		RuntimeEvent,
+		RuntimeError,
+		RuntimeOrigin,
+		RuntimeFreezeReason,
+		RuntimeHoldReason,
+		RuntimeSlashReason,
+		RuntimeLockId,
+		RuntimeTask,
+		RuntimeViewFunction
+	)]
+	pub struct Runtime;
+
+	#[runtime::pallet_index(0)]
+	pub type System = self::frame_system;
+}
+
+impl frame_system::Config for Runtime {
+	type Block = Block;
+	type AccountId = u64;
+	type BaseCallFilter = crate::traits::Everything;
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeTask = ();
+	type PalletInfo = PalletInfo;
+	type DbWeight = ();
+	type DispatchExtension = (DispatchExt1, DispatchExt2, DispatchExt3);
+}
+
+fn new_test_ext() -> TestExternalities {
+	RuntimeGenesisConfig::default().build_storage().unwrap().into()
+}
+
+// -- Mock extensions ------------------------------------------------------------
+
+parameter_types! {
+	pub static DispatchExt1ShouldFail: bool = false;
+	pub static DispatchExt1StorageWrite: bool = false;
+	pub static DispatchExt2ShouldFail: bool = false;
+	pub static DispatchExt3ShouldFail: bool = false;
+	pub static PostDispatchCalled: bool = false;
+}
+
+pub struct DispatchExt1;
+impl DispatchExtension<RuntimeCall> for DispatchExt1 {
+	type Pre = ();
+
+	fn weight(_call: &RuntimeCall) -> crate::weights::Weight {
+		crate::weights::Weight::zero()
+	}
+
+	fn pre_dispatch(
+		_origin: &RuntimeOrigin,
+		_call: &RuntimeCall,
+	) -> Result<Self::Pre, crate::dispatch::DispatchErrorWithPostInfo> {
+		if DispatchExt1StorageWrite::get() {
+			crate::storage::unhashed::put_raw(b"dispatch_ext_write", b"written");
+		}
+		if DispatchExt1ShouldFail::get() {
+			return Err(DispatchError::Other("first guard rejected").into());
+		}
+		Ok(())
+	}
+
+	fn post_dispatch(_pre: Self::Pre, _result: &DispatchResultWithPostInfo) {}
+}
+
+pub struct DispatchExt2;
+impl DispatchExtension<RuntimeCall> for DispatchExt2 {
+	type Pre = ();
+
+	fn weight(_call: &RuntimeCall) -> crate::weights::Weight {
+		crate::weights::Weight::zero()
+	}
+
+	fn pre_dispatch(
+		_origin: &RuntimeOrigin,
+		_call: &RuntimeCall,
+	) -> Result<Self::Pre, crate::dispatch::DispatchErrorWithPostInfo> {
+		if DispatchExt2ShouldFail::get() {
+			return Err(DispatchError::Other("second guard rejected").into());
+		}
+		Ok(())
+	}
+
+	fn post_dispatch(_pre: Self::Pre, _result: &DispatchResultWithPostInfo) {}
+}
+
+pub struct DispatchExt3;
+impl DispatchExtension<RuntimeCall> for DispatchExt3 {
+	type Pre = ();
+
+	fn weight(_call: &RuntimeCall) -> crate::weights::Weight {
+		crate::weights::Weight::zero()
+	}
+
+	fn pre_dispatch(
+		_origin: &RuntimeOrigin,
+		_call: &RuntimeCall,
+	) -> Result<Self::Pre, crate::dispatch::DispatchErrorWithPostInfo> {
+		if DispatchExt3ShouldFail::get() {
+			return Err(DispatchError::Other("third guard rejected").into());
+		}
+		Ok(())
+	}
+
+	fn post_dispatch(_pre: Self::Pre, _result: &DispatchResultWithPostInfo) {
+		PostDispatchCalled::set(true);
+	}
+}
+
+// -- Tests ----------------------------------------------------------------------
+
+type TestDispatchExtension = <Runtime as frame_system::Config>::DispatchExtension;
+
+const CALL: &RuntimeCall = &RuntimeCall::System(frame_system::Call::noop {});
+
+#[test]
+fn pre_dispatch_passes_when_all_allow() {
+	new_test_ext().execute_with(|| {
+		let origin = RuntimeOrigin::signed(1);
+		assert_ok!(TestDispatchExtension::pre_dispatch(&origin, CALL));
+	});
+}
+
+#[test]
+fn pre_dispatch_first_rejects() {
+	new_test_ext().execute_with(|| {
+		DispatchExt1ShouldFail::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		assert_noop!(
+			TestDispatchExtension::pre_dispatch(&origin, CALL),
+			DispatchError::Other("first guard rejected")
+		);
+	});
+}
+
+#[test]
+fn pre_dispatch_none_origin_rejects() {
+	new_test_ext().execute_with(|| {
+		DispatchExt1ShouldFail::set(true);
+		let origin = RuntimeOrigin::none();
+		assert_noop!(
+			TestDispatchExtension::pre_dispatch(&origin, CALL),
+			DispatchError::Other("first guard rejected")
+		);
+	});
+}
+
+#[test]
+fn rolls_back_storage_writes() {
+	new_test_ext().execute_with(|| {
+		DispatchExt1StorageWrite::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		let _ =
+			<TestDispatchExtension as ExtendedDispatchable<RuntimeCall>>::dispatch_with_extension(
+				origin,
+				CALL.clone(),
+			);
+		assert!(!crate::storage::unhashed::exists(b"dispatch_ext_write"));
+	});
+}
+
+#[test]
+fn rolls_back_storage_writes_on_failure() {
+	new_test_ext().execute_with(|| {
+		DispatchExt1StorageWrite::set(true);
+		DispatchExt1ShouldFail::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		let _ =
+			<TestDispatchExtension as ExtendedDispatchable<RuntimeCall>>::dispatch_with_extension(
+				origin,
+				CALL.clone(),
+			);
+		assert!(!crate::storage::unhashed::exists(b"dispatch_ext_write"));
+	});
+}
+
+#[test]
+fn tuple_second_rejects() {
+	new_test_ext().execute_with(|| {
+		DispatchExt2ShouldFail::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		assert_noop!(
+			TestDispatchExtension::pre_dispatch(&origin, CALL),
+			DispatchError::Other("second guard rejected")
+		);
+	});
+}
+
+#[test]
+fn tuple_third_rejects() {
+	new_test_ext().execute_with(|| {
+		DispatchExt3ShouldFail::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		assert_noop!(
+			TestDispatchExtension::pre_dispatch(&origin, CALL),
+			DispatchError::Other("third guard rejected")
+		);
+	});
+}
+
+#[test]
+fn tuple_first_short_circuits() {
+	new_test_ext().execute_with(|| {
+		DispatchExt1ShouldFail::set(true);
+		DispatchExt2ShouldFail::set(true);
+		DispatchExt3ShouldFail::set(true);
+		let origin = RuntimeOrigin::signed(1);
+		assert_noop!(
+			TestDispatchExtension::pre_dispatch(&origin, CALL),
+			DispatchError::Other("first guard rejected")
+		);
+	});
+}
+
+#[test]
+fn post_dispatch_runs() {
+	new_test_ext().execute_with(|| {
+		let origin = RuntimeOrigin::signed(1);
+		let pre = TestDispatchExtension::pre_dispatch(&origin, CALL).unwrap();
+		PostDispatchCalled::set(false);
+		let result: DispatchResultWithPostInfo = Ok(().into());
+		TestDispatchExtension::post_dispatch(pre, &result);
+		assert!(PostDispatchCalled::get());
+	});
+}
+
+#[test]
+fn post_dispatch_runs_on_failed_dispatch() {
+	new_test_ext().execute_with(|| {
+		let origin = RuntimeOrigin::signed(1);
+		let pre = TestDispatchExtension::pre_dispatch(&origin, CALL).unwrap();
+		PostDispatchCalled::set(false);
+		let result: DispatchResultWithPostInfo = Err(DispatchError::Other("call failed").into());
+		TestDispatchExtension::post_dispatch(pre, &result);
+		assert!(PostDispatchCalled::get());
+	});
+}
+
+#[test]
+fn dispatch_with_extension_runs_full_flow() {
+	new_test_ext().execute_with(|| {
+		PostDispatchCalled::set(false);
+		let origin = RuntimeOrigin::signed(1);
+		let result =
+			<TestDispatchExtension as ExtendedDispatchable<RuntimeCall>>::dispatch_with_extension(
+				origin,
+				CALL.clone(),
+			);
+		assert_ok!(&result);
+		assert!(PostDispatchCalled::get());
+	});
+}
+
+#[test]
+fn dispatch_with_extension_post_dispatch_runs_on_failed_call() {
+	new_test_ext().execute_with(|| {
+		PostDispatchCalled::set(false);
+		let origin = RuntimeOrigin::signed(1);
+		let bad_call = RuntimeCall::System(frame_system::Call::always_fails {});
+		let result =
+			<TestDispatchExtension as ExtendedDispatchable<RuntimeCall>>::dispatch_with_extension(
+				origin, bad_call,
+			);
+		assert!(result.is_err());
+		assert!(PostDispatchCalled::get());
+	});
+}

--- a/substrate/frame/support/src/tests/dispatch_extension.rs
+++ b/substrate/frame/support/src/tests/dispatch_extension.rs
@@ -125,7 +125,7 @@ impl DispatchExtension<RuntimeCall> for DispatchExt1 {
 	type Pre = ();
 
 	fn weight(_call: &RuntimeCall) -> crate::weights::Weight {
-		crate::weights::Weight::zero()
+		crate::weights::Weight::from_parts(100, 0)
 	}
 
 	fn pre_dispatch(
@@ -149,7 +149,7 @@ impl DispatchExtension<RuntimeCall> for DispatchExt2 {
 	type Pre = ();
 
 	fn weight(_call: &RuntimeCall) -> crate::weights::Weight {
-		crate::weights::Weight::zero()
+		crate::weights::Weight::from_parts(200, 0)
 	}
 
 	fn pre_dispatch(
@@ -170,7 +170,7 @@ impl DispatchExtension<RuntimeCall> for DispatchExt3 {
 	type Pre = ();
 
 	fn weight(_call: &RuntimeCall) -> crate::weights::Weight {
-		crate::weights::Weight::zero()
+		crate::weights::Weight::from_parts(50, 0)
 	}
 
 	fn pre_dispatch(
@@ -345,4 +345,14 @@ fn dispatch_with_extension_post_dispatch_runs_on_failed_call() {
 		assert!(result.is_err());
 		assert!(PostDispatchCalled::get());
 	});
+}
+
+#[test]
+fn get_dispatch_info_includes_extension_weight() {
+	use crate::dispatch::GetDispatchInfo;
+
+	let call = RuntimeCall::System(frame_system::Call::noop {});
+	let info = call.get_dispatch_info();
+	// noop has weight 0, extensions add 100 + 200 + 50 = 350
+	assert_eq!(info.call_weight, crate::weights::Weight::from_parts(350, 0));
 }

--- a/substrate/frame/support/src/tests/mod.rs
+++ b/substrate/frame/support/src/tests/mod.rs
@@ -26,6 +26,7 @@ use sp_runtime::{generic, traits::BlakeTwo256, BuildStorage};
 
 pub use self::frame_system::{pallet_prelude::*, Config, Pallet};
 
+mod dispatch_extension;
 mod storage_alias;
 
 #[pallet]
@@ -52,6 +53,7 @@ pub mod frame_system {
 			#[inject_runtime_type]
 			type RuntimeTask = ();
 			type DbWeight = ();
+			type DispatchExtension = ();
 		}
 	}
 
@@ -69,12 +71,14 @@ pub mod frame_system {
 		#[pallet::no_default_bounds]
 		type RuntimeOrigin;
 		#[pallet::no_default_bounds]
-		type RuntimeCall;
+		type RuntimeCall: sp_runtime::traits::Dispatchable;
 		#[pallet::no_default_bounds]
 		type RuntimeTask: crate::traits::tasks::Task;
 		#[pallet::no_default_bounds]
 		type PalletInfo: crate::traits::PalletInfo;
 		type DbWeight: Get<crate::weights::RuntimeDbWeight>;
+		#[pallet::no_default_bounds]
+		type DispatchExtension: crate::traits::DispatchExtension<Self::RuntimeCall>;
 		#[pallet::constant]
 		#[pallet::no_default]
 		#[deprecated = "this constant is deprecated"]

--- a/substrate/frame/support/src/traits.rs
+++ b/substrate/frame/support/src/traits.rs
@@ -106,9 +106,10 @@ mod dispatch;
 #[allow(deprecated)]
 pub use dispatch::EnsureOneOf;
 pub use dispatch::{
-	AsEnsureOriginWithArg, Authorize, CallerTrait, EitherOf, EitherOfDiverse, EnsureOrigin,
-	EnsureOriginEqualOrHigherPrivilege, EnsureOriginWithArg, MapSuccess, NeverEnsureOrigin,
-	OriginTrait, TryMapSuccess, TryWithMorphedArg, UnfilteredDispatchable,
+	AsEnsureOriginWithArg, Authorize, CallerTrait, DispatchExtension, EitherOf, EitherOfDiverse,
+	EnsureOrigin, EnsureOriginEqualOrHigherPrivilege, EnsureOriginWithArg, ExtendedDispatchable,
+	MapSuccess, NeverEnsureOrigin, OriginTrait, TryMapSuccess, TryWithMorphedArg,
+	UnfilteredDispatchable,
 };
 
 mod voting;

--- a/substrate/frame/support/src/traits/dispatch.rs
+++ b/substrate/frame/support/src/traits/dispatch.rs
@@ -17,11 +17,14 @@
 
 //! Traits for dealing with dispatching calls and the origin from which they are dispatched.
 
-use crate::dispatch::{DispatchResultWithPostInfo, Parameter, RawOrigin};
+use crate::{
+	dispatch::{DispatchErrorWithPostInfo, DispatchResultWithPostInfo, Parameter, RawOrigin},
+	storage::{transactional::with_transaction, TransactionOutcome},
+};
 use codec::MaxEncodedLen;
 use core::{cmp::Ordering, marker::PhantomData};
 use sp_runtime::{
-	traits::{BadOrigin, Get, Member, Morph, TryMorph},
+	traits::{BadOrigin, Dispatchable, Get, Member, Morph, TryMorph},
 	transaction_validity::{TransactionSource, TransactionValidityError, ValidTransaction},
 	Either,
 };
@@ -449,6 +452,83 @@ pub trait UnfilteredDispatchable {
 
 	/// Dispatch this call but do not check the filter in origin.
 	fn dispatch_bypass_filter(self, origin: Self::RuntimeOrigin) -> DispatchResultWithPostInfo;
+}
+
+/// Orchestrates a `DispatchExtension` around the call dispatch in a single method.
+/// Pre-dispatch runs in a rolled-back storage layer. Post-dispatch always runs.
+/// Blanket-implemented for all `DispatchExtension` implementors.
+pub trait ExtendedDispatchable<Call: Dispatchable>: DispatchExtension<Call> {
+	fn dispatch_with_extension(
+		origin: Call::RuntimeOrigin,
+		call: Call,
+	) -> DispatchResultWithPostInfo;
+}
+
+impl<T, Call, Origin> ExtendedDispatchable<Call> for T
+where
+	T: DispatchExtension<Call>,
+	Origin: Into<<Call as Dispatchable>::RuntimeOrigin>,
+	Call: Dispatchable<RuntimeOrigin = Origin> + UnfilteredDispatchable<RuntimeOrigin = Origin>,
+{
+	fn dispatch_with_extension(origin: Origin, call: Call) -> DispatchResultWithPostInfo {
+		let pre = with_transaction(|| {
+			let result = T::pre_dispatch(&origin, &call);
+			TransactionOutcome::Rollback(result)
+		})?;
+
+		let result = UnfilteredDispatchable::dispatch_bypass_filter(call, origin);
+		T::post_dispatch(pre, &result);
+
+		result
+	}
+}
+
+/// A `DispatchExtension` is executed around the `Call` dispatch. It provides:
+/// - `pre_dispatch`: runs in a rolled-back storage layer (no writes persist), can gate the call and
+///   capture state for `post_dispatch`.
+/// - `post_dispatch`: runs after dispatch, can persist storage writes (e.g. rate limiting), cannot
+///   fail.
+///
+/// The trait is implemented for all tuples of up to 30 elements.
+pub trait DispatchExtension<Call: Dispatchable> {
+	/// Data produced by `pre_dispatch` and passed to `post_dispatch`.
+	type Pre;
+
+	/// Worst-case weight consumed by this extension.
+	fn weight(call: &Call) -> Weight;
+
+	/// Called before dispatch. Runs in a rolled-back storage layer (no writes persist).
+	/// Can gate the call or capture state for `post_dispatch`.
+	fn pre_dispatch(
+		origin: &Call::RuntimeOrigin,
+		call: &Call,
+	) -> Result<Self::Pre, DispatchErrorWithPostInfo>;
+
+	/// Called after dispatch. Cannot fail. Storage writes persist.
+	/// Receives the pre-dispatch data and the dispatch result.
+	fn post_dispatch(pre: Self::Pre, result: &DispatchResultWithPostInfo);
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+impl<Call: Dispatchable> DispatchExtension<Call> for Tuple {
+	for_tuples!( type Pre = ( #( Tuple::Pre ),* ); );
+
+	fn weight(call: &Call) -> Weight {
+		let mut weight = Weight::zero();
+		for_tuples!( #( weight = weight.saturating_add(Tuple::weight(call)); )* );
+		weight
+	}
+
+	fn pre_dispatch(
+		origin: &Call::RuntimeOrigin,
+		call: &Call,
+	) -> Result<Self::Pre, DispatchErrorWithPostInfo> {
+		Ok(for_tuples!( ( #( Tuple::pre_dispatch(origin, call)? ),* ) ))
+	}
+
+	fn post_dispatch(pre: Self::Pre, result: &DispatchResultWithPostInfo) {
+		for_tuples!( #( Tuple::post_dispatch(pre.Tuple, result); )* );
+	}
 }
 
 /// The trait implemented by the overarching enumeration of the different pallets' origins.

--- a/substrate/frame/support/test/src/lib.rs
+++ b/substrate/frame/support/test/src/lib.rs
@@ -49,9 +49,11 @@ pub mod pallet {
 		type RuntimeOrigin: Into<Result<RawOrigin<Self::AccountId>, Self::RuntimeOrigin>>
 			+ From<RawOrigin<Self::AccountId>>;
 		/// The runtime call type.
-		type RuntimeCall;
+		type RuntimeCall: sp_runtime::traits::Dispatchable;
 		/// Contains an aggregation of all tasks in this runtime.
 		type RuntimeTask;
+		/// The dispatch extension.
+		type DispatchExtension: frame_support::traits::DispatchExtension<Self::RuntimeCall>;
 		/// The runtime event type.
 		type RuntimeEvent: Parameter
 			+ Member

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -127,16 +127,16 @@ use codec::{Decode, DecodeWithMemTracking, Encode, EncodeLike, FullCodec, MaxEnc
 use frame_support::traits::BuildGenesisConfig;
 use frame_support::{
 	dispatch::{
-		extract_actual_pays_fee, extract_actual_weight, DispatchClass, DispatchGuard, DispatchInfo,
-		DispatchResult, DispatchResultWithPostInfo, GetDispatchInfo, PerDispatchClass,
-		PostDispatchInfo,
+		extract_actual_pays_fee, extract_actual_weight, DispatchClass, DispatchExtension,
+		DispatchInfo, DispatchResult, DispatchResultWithPostInfo, GetDispatchInfo,
+		PerDispatchClass, PostDispatchInfo,
 	},
 	ensure, impl_ensure_origin_with_arg_ignoring_arg,
 	migrations::MultiStepMigrator,
 	pallet_prelude::Pays,
-	storage::{self, transactional::with_transaction, StorageStreamIter, TransactionOutcome},
+	storage::{self, StorageStreamIter},
 	traits::{
-		CallerTrait, ConstU32, Contains, EnsureOrigin, EnsureOriginWithArg, Get, HandleLifetime,
+		ConstU32, Contains, EnsureOrigin, EnsureOriginWithArg, Get, HandleLifetime,
 		OnKilledAccount, OnNewAccount, OnRuntimeUpgrade, OriginTrait, PalletInfo, SortedMembers,
 		StoredMap, TypedGet,
 	},
@@ -372,7 +372,7 @@ pub mod pallet {
 			type PreInherents = ();
 			type PostInherents = ();
 			type PostTransactions = ();
-			type DispatchGuard = ();
+			type DispatchExtension = ();
 		}
 
 		/// Default configurations of this pallet in a solochain environment.
@@ -475,7 +475,7 @@ pub mod pallet {
 			type PreInherents = ();
 			type PostInherents = ();
 			type PostTransactions = ();
-			type DispatchGuard = ();
+			type DispatchExtension = ();
 		}
 
 		/// Default configurations of this pallet in a relay-chain environment.
@@ -693,9 +693,9 @@ pub mod pallet {
 		/// See `frame_executive::block_flowchart` for a in-depth explanation when it runs.
 		type PostTransactions: PostTransactions;
 
-		/// The dispatch guard to use in dispatchable.
+		/// The dispatch extension executed around dispatchable calls.
 		#[pallet::no_default_bounds]
-		type DispatchGuard: DispatchGuard<Self::RuntimeCall>;
+		type DispatchExtension: DispatchExtension<Self::RuntimeCall>;
 	}
 
 	#[pallet::pallet]
@@ -2391,23 +2391,6 @@ impl<T: Config> Pallet<T> {
 		}
 
 		Ok(())
-	}
-
-	pub fn check_dispatch_guard(
-		origin: &T::RuntimeOrigin,
-		call: &T::RuntimeCall,
-	) -> DispatchResultWithPostInfo {
-		// Root bypasses the dispatch guard.
-		if origin.caller().is_root() {
-			return Ok(().into());
-		}
-
-		// Wrap the dispatch guard in a transaction layer and we rollback
-		// to prevent any writes.
-		with_transaction(|| {
-			let result = T::DispatchGuard::check(origin, call);
-			TransactionOutcome::Rollback(result)
-		})
 	}
 }
 

--- a/substrate/frame/system/src/mock.rs
+++ b/substrate/frame/system/src/mock.rs
@@ -96,60 +96,11 @@ impl Config for Test {
 	type OnKilledAccount = RecordKilled;
 	type MultiBlockMigrator = MockedMigrator;
 	type Nonce = TypeWithDefault<u64, DefaultNonceProvider>;
-	type DispatchGuard = (DispatchGuard1, DispatchGuard2, DispatchGuard3);
+	type DispatchExtension = ();
 }
 
 parameter_types! {
 	pub static Ongoing: bool = false;
-}
-
-parameter_types! {
-	pub static DispatchGuard1ShouldFail: bool = false;
-	pub static DispatchGuard1StorageWrite: bool = false;
-	pub static DispatchGuard2ShouldFail: bool = false;
-	pub static DispatchGuard3ShouldFail: bool = false;
-}
-
-pub struct DispatchGuard1;
-impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for DispatchGuard1 {
-	fn check(
-		_origin: &<Test as Config>::RuntimeOrigin,
-		_call: &<Test as Config>::RuntimeCall,
-	) -> frame_support::dispatch::DispatchResultWithPostInfo {
-		if DispatchGuard1StorageWrite::get() {
-			frame_support::storage::unhashed::put_raw(b"dispatch_guard_write", b"written");
-		}
-		if DispatchGuard1ShouldFail::get() {
-			return Err(sp_runtime::DispatchError::Other("first guard rejected").into());
-		}
-		Ok(().into())
-	}
-}
-
-pub struct DispatchGuard2;
-impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for DispatchGuard2 {
-	fn check(
-		_origin: &<Test as Config>::RuntimeOrigin,
-		_call: &<Test as Config>::RuntimeCall,
-	) -> frame_support::dispatch::DispatchResultWithPostInfo {
-		if DispatchGuard2ShouldFail::get() {
-			return Err(sp_runtime::DispatchError::Other("second guard rejected").into());
-		}
-		Ok(().into())
-	}
-}
-
-pub struct DispatchGuard3;
-impl frame_support::dispatch::DispatchGuard<<Test as Config>::RuntimeCall> for DispatchGuard3 {
-	fn check(
-		_origin: &<Test as Config>::RuntimeOrigin,
-		_call: &<Test as Config>::RuntimeCall,
-	) -> frame_support::dispatch::DispatchResultWithPostInfo {
-		if DispatchGuard3ShouldFail::get() {
-			return Err(sp_runtime::DispatchError::Other("third guard rejected").into());
-		}
-		Ok(().into())
-	}
 }
 
 pub struct MockedMigrator;

--- a/substrate/frame/system/src/tests.rs
+++ b/substrate/frame/system/src/tests.rs
@@ -18,7 +18,7 @@
 use crate::*;
 use frame_support::{
 	assert_noop, assert_ok,
-	dispatch::{Pays, PostDispatchInfo, WithPostDispatchInfo},
+	dispatch::{DispatchResultWithPostInfo, Pays, PostDispatchInfo, WithPostDispatchInfo},
 	traits::{OnRuntimeUpgrade, WhitelistedStorageKeys},
 };
 use mock::{RuntimeOrigin, *};
@@ -962,123 +962,5 @@ fn reclaim_works() {
 
 		System::note_applied_extrinsic(&Ok(().into()), Default::default());
 		assert_eq!(crate::ExtrinsicWeightReclaimed::<Test>::get(), Weight::zero());
-	});
-}
-
-#[test]
-fn dispatch_guard_root_bypasses() {
-	new_test_ext().execute_with(|| {
-		// Root should always bypass the dispatch guard, even if all guards would reject.
-		mock::DispatchGuard1ShouldFail::set(true);
-		mock::DispatchGuard2ShouldFail::set(true);
-		mock::DispatchGuard3ShouldFail::set(true);
-		let origin = RuntimeOrigin::root();
-		assert_ok!(System::check_dispatch_guard(&origin, CALL));
-	});
-}
-
-#[test]
-fn dispatch_guard_signed_passes_when_all_guards_allow() {
-	new_test_ext().execute_with(|| {
-		let origin = RuntimeOrigin::signed(1);
-		assert_ok!(System::check_dispatch_guard(&origin, CALL));
-	});
-}
-
-#[test]
-fn dispatch_guard_signed_fails_when_first_guard_rejects() {
-	new_test_ext().execute_with(|| {
-		mock::DispatchGuard1ShouldFail::set(true);
-		let origin = RuntimeOrigin::signed(1);
-		assert_noop!(
-			System::check_dispatch_guard(&origin, CALL),
-			DispatchError::Other("first guard rejected")
-		);
-	});
-}
-
-#[test]
-fn dispatch_guard_none_origin_fails_when_guard_rejects() {
-	new_test_ext().execute_with(|| {
-		mock::DispatchGuard1ShouldFail::set(true);
-		let origin = RuntimeOrigin::none();
-		assert_noop!(
-			System::check_dispatch_guard(&origin, CALL),
-			DispatchError::Other("first guard rejected")
-		);
-	});
-}
-
-#[test]
-fn dispatch_guard_rolls_back_storage_writes() {
-	new_test_ext().execute_with(|| {
-		// Enable storage writes inside the first guard.
-		mock::DispatchGuard1StorageWrite::set(true);
-
-		let origin = RuntimeOrigin::signed(1);
-		assert_ok!(System::check_dispatch_guard(&origin, CALL));
-
-		// Storage write from inside the guard must have been rolled back.
-		assert!(!frame_support::storage::unhashed::exists(b"dispatch_guard_write"));
-	});
-}
-
-#[test]
-fn dispatch_guard_rolls_back_storage_writes_on_failure() {
-	new_test_ext().execute_with(|| {
-		// Enable storage writes and make the guard fail.
-		mock::DispatchGuard1StorageWrite::set(true);
-		mock::DispatchGuard1ShouldFail::set(true);
-
-		let origin = RuntimeOrigin::signed(1);
-		assert_noop!(
-			System::check_dispatch_guard(&origin, CALL),
-			DispatchError::Other("first guard rejected")
-		);
-
-		// Storage write must be rolled back regardless of guard outcome.
-		assert!(!frame_support::storage::unhashed::exists(b"dispatch_guard_write"));
-	});
-}
-
-#[test]
-fn dispatch_guard_tuple_second_guard_rejects() {
-	new_test_ext().execute_with(|| {
-		// First guard passes, second rejects — should surface the second guard's error.
-		mock::DispatchGuard2ShouldFail::set(true);
-		let origin = RuntimeOrigin::signed(1);
-		assert_noop!(
-			System::check_dispatch_guard(&origin, CALL),
-			DispatchError::Other("second guard rejected")
-		);
-	});
-}
-
-#[test]
-fn dispatch_guard_tuple_third_guard_rejects() {
-	new_test_ext().execute_with(|| {
-		// First two guards pass, third rejects.
-		mock::DispatchGuard3ShouldFail::set(true);
-		let origin = RuntimeOrigin::signed(1);
-		assert_noop!(
-			System::check_dispatch_guard(&origin, CALL),
-			DispatchError::Other("third guard rejected")
-		);
-	});
-}
-
-#[test]
-fn dispatch_guard_tuple_first_guard_short_circuits() {
-	new_test_ext().execute_with(|| {
-		// All three guards would reject, but the first one should short-circuit
-		// and we should see its error, not the others.
-		mock::DispatchGuard1ShouldFail::set(true);
-		mock::DispatchGuard2ShouldFail::set(true);
-		mock::DispatchGuard3ShouldFail::set(true);
-		let origin = RuntimeOrigin::signed(1);
-		assert_noop!(
-			System::check_dispatch_guard(&origin, CALL),
-			DispatchError::Other("first guard rejected")
-		);
 	});
 }


### PR DESCRIPTION
Duplicate of #16 that got erroneously merged into `ci-works` after it was merged

## Evolve `DispatchGuard` into `DispatchExtension` with pre/post hooks and weight accounting

For context, see #8 

### Summary

- Replaces the read-only `DispatchGuard` trait with a full `DispatchExtension` trait that provides `pre_dispatch` (read-only, rolled-back storage layer) and `post_dispatch` (infallible, writes persist) hooks around every dispatched call
- Adds `ExtendedDispatchable` blanket-implemented trait that orchestrates the pre → dispatch → post flow in a single `dispatch_with_extension` method
- Integrates extension weight into `RuntimeCall::get_dispatch_info()` so the block proposer and fee system correctly account for extension cost upfront
- Moves dispatch extension tests to `frame-support` with a self-contained mock runtime

### Motivation

`DispatchGuard` was a simple pre-dispatch gate (pass/reject). We need richer hooks that can:

- **Capture state** before dispatch and use it after (e.g., compare balances before/after)
- **Persist storage writes** after dispatch (e.g., rate limiting, metering)
- **Declare weight** so the block proposer rejects extrinsics when the block is full

### Design

**`DispatchExtension<Call>` trait** (`frame-support/src/traits/dispatch.rs`):

- `type Pre` — data captured in pre and passed to post
- `weight(call)` — worst-case weight for the extension
- `pre_dispatch(origin, call) -> Result<Pre, Error>` — runs in rolled-back storage layer, can reject
- `post_dispatch(pre, result)` — infallible, storage writes persist

**`ExtendedDispatchable<Call>` trait** (blanket impl for all `DispatchExtension` implementors):

- Single method `dispatch_with_extension(origin, call)` that wraps the full flow
- `pre_dispatch` runs inside `with_transaction` + `TransactionOutcome::Rollback`
- `post_dispatch` always runs (even if dispatch fails)

**Generated `RuntimeCall::dispatch()`** calls `ExtendedDispatchable::dispatch_with_extension` after origin filtering. Benchmarks use `dispatch_bypass_filter()` directly, so they naturally skip the extension.

**Weight accounting**: The generated `RuntimeCall::get_dispatch_info()` adds the dispatch extension weight (sum of all tuple elements) into `call_weight`. No new fields on `DispatchInfo` — the existing fee/block-weight pipeline handles it transparently. No per-execution refund; worst-case is always charged.