### PR TITLE
Root should bypass dispatch extension

### DIFF
--- a/substrate/frame/support/src/tests/dispatch_extension.rs
+++ b/substrate/frame/support/src/tests/dispatch_extension.rs
@@ -348,6 +348,36 @@ fn dispatch_with_extension_post_dispatch_runs_on_failed_call() {
 }
 
 #[test]
+fn root_bypasses_extension_even_when_rejecting() {
+	new_test_ext().execute_with(|| {
+		DispatchExt1ShouldFail::set(true);
+		let origin = RuntimeOrigin::root();
+		// A signed origin would be rejected; root must succeed.
+		assert_ok!(
+			<TestDispatchExtension as ExtendedDispatchable<RuntimeCall>>::dispatch_with_extension(
+				origin,
+				CALL.clone(),
+			)
+		);
+	});
+}
+
+#[test]
+fn root_bypasses_extension_skips_post_dispatch() {
+	new_test_ext().execute_with(|| {
+		PostDispatchCalled::set(false);
+		let origin = RuntimeOrigin::root();
+		assert_ok!(
+			<TestDispatchExtension as ExtendedDispatchable<RuntimeCall>>::dispatch_with_extension(
+				origin,
+				CALL.clone(),
+			)
+		);
+		assert!(!PostDispatchCalled::get());
+	});
+}
+
+#[test]
 fn get_dispatch_info_includes_extension_weight() {
 	use crate::dispatch::GetDispatchInfo;
 

--- a/substrate/frame/support/src/traits/dispatch.rs
+++ b/substrate/frame/support/src/traits/dispatch.rs
@@ -467,10 +467,15 @@ pub trait ExtendedDispatchable<Call: Dispatchable>: DispatchExtension<Call> {
 impl<T, Call, Origin> ExtendedDispatchable<Call> for T
 where
 	T: DispatchExtension<Call>,
-	Origin: Into<<Call as Dispatchable>::RuntimeOrigin>,
+	Origin: Into<<Call as Dispatchable>::RuntimeOrigin> + OriginTrait,
 	Call: Dispatchable<RuntimeOrigin = Origin> + UnfilteredDispatchable<RuntimeOrigin = Origin>,
 {
 	fn dispatch_with_extension(origin: Origin, call: Call) -> DispatchResultWithPostInfo {
+		// Root origin bypasses the extension.
+		if origin.caller().is_root() {
+			return UnfilteredDispatchable::dispatch_bypass_filter(call, origin);
+		}
+
 		let pre = with_transaction(|| {
 			let result = T::pre_dispatch(&origin, &call);
 			TransactionOutcome::Rollback(result)
@@ -506,7 +511,7 @@ pub trait DispatchExtension<Call: Dispatchable> {
 
 	/// Called after dispatch. Cannot fail. Storage writes persist.
 	/// Receives the pre-dispatch data and the dispatch result.
-	fn post_dispatch(pre: Self::Pre, result: &DispatchResultWithPostInfo);
+	fn post_dispatch(_pre: Self::Pre, _result: &DispatchResultWithPostInfo) {}
 }
 
 #[impl_trait_for_tuples::impl_for_tuples(30)]


### PR DESCRIPTION
### Description

- Fixed the case where origin is `Root` to bypass the extension completely (same behavior as `BaseCallFilter`).
- `post_dispatch` as optional when defining extension.