### PR TITLE
Extend GetCallMetadata with get_call_indices

### DIFF
--- a/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -179,6 +179,19 @@ pub fn expand_outer_dispatch(
 					_ => unreachable!(),
 				}
 			}
+
+			fn get_call_indices(module: &str) -> &'static [u8] {
+				use #scrate::{dispatch::Callable, traits::GetCallIndex};
+				match module {
+					#(
+						#pallet_attrs
+						stringify!(#pallet_names) =>
+							<<#pallet_names as Callable<#runtime>>::RuntimeCall
+								as GetCallIndex>::get_call_indices(),
+					)*
+					_ => unreachable!(),
+				}
+			}
 		}
 		impl #scrate::__private::Dispatchable for RuntimeCall {
 			type RuntimeOrigin = RuntimeOrigin;

--- a/substrate/frame/support/src/traits/metadata.rs
+++ b/substrate/frame/support/src/traits/metadata.rs
@@ -126,8 +126,10 @@ pub trait GetCallMetadata {
 	fn get_module_names() -> &'static [&'static str];
 	/// Return all module indices in the same order as [`get_module_names`].
 	fn get_module_indices() -> &'static [u8];
-	/// Return all function names for the given `module`.
+	/// Return all function names for the given `module` in the same order as [`get_call_indices`].
 	fn get_call_names(module: &str) -> &'static [&'static str];
+	/// Return all function indices for the given `module` in the same order as [`get_call_names`].
+	fn get_call_indices(module: &str) -> &'static [u8];
 	/// Return a [`CallMetadata`], containing function and pallet name of the Call.
 	fn get_call_metadata(&self) -> CallMetadata;
 }

--- a/substrate/frame/support/test/tests/runtime.rs
+++ b/substrate/frame/support/test/tests/runtime.rs
@@ -759,11 +759,7 @@ fn get_call_names_and_indices() {
 			("aux_4", 4),
 			("operational", 5),
 		],
-		call_names
-			.iter()
-			.copied()
-			.zip(call_indices.iter().copied())
-			.collect::<Vec<_>>()
+		call_names.iter().copied().zip(call_indices.iter().copied()).collect::<Vec<_>>()
 	);
 }
 

--- a/substrate/frame/support/test/tests/runtime.rs
+++ b/substrate/frame/support/test/tests/runtime.rs
@@ -746,6 +746,28 @@ fn get_module_names_and_indices() {
 }
 
 #[test]
+fn get_call_names_and_indices() {
+	use frame_support::traits::GetCallMetadata;
+	let call_names = RuntimeCall::get_call_names("Module3");
+	let call_indices = RuntimeCall::get_call_indices("Module3");
+	assert_eq!(
+		vec![
+			("fail", 0),
+			("aux_1", 1),
+			("aux_2", 2),
+			("aux_3", 3),
+			("aux_4", 4),
+			("operational", 5),
+		],
+		call_names
+			.iter()
+			.copied()
+			.zip(call_indices.iter().copied())
+			.collect::<Vec<_>>()
+	);
+}
+
+#[test]
 fn call_subtype_conversion() {
 	use frame_support::{dispatch::CallableCallFor, traits::IsSubType};
 	let call = RuntimeCall::Module3(module3::Call::<Runtime>::fail {});

--- a/substrate/frame/support/test/tests/runtime_legacy_ordering.rs
+++ b/substrate/frame/support/test/tests/runtime_legacy_ordering.rs
@@ -759,11 +759,7 @@ fn get_call_names_and_indices() {
 			("aux_4", 4),
 			("operational", 5),
 		],
-		call_names
-			.iter()
-			.copied()
-			.zip(call_indices.iter().copied())
-			.collect::<Vec<_>>()
+		call_names.iter().copied().zip(call_indices.iter().copied()).collect::<Vec<_>>()
 	);
 }
 

--- a/substrate/frame/support/test/tests/runtime_legacy_ordering.rs
+++ b/substrate/frame/support/test/tests/runtime_legacy_ordering.rs
@@ -746,6 +746,28 @@ fn get_module_names_and_indices() {
 }
 
 #[test]
+fn get_call_names_and_indices() {
+	use frame_support::traits::GetCallMetadata;
+	let call_names = RuntimeCall::get_call_names("Module3");
+	let call_indices = RuntimeCall::get_call_indices("Module3");
+	assert_eq!(
+		vec![
+			("fail", 0),
+			("aux_1", 1),
+			("aux_2", 2),
+			("aux_3", 3),
+			("aux_4", 4),
+			("operational", 5),
+		],
+		call_names
+			.iter()
+			.copied()
+			.zip(call_indices.iter().copied())
+			.collect::<Vec<_>>()
+	);
+}
+
+#[test]
 fn call_subtype_conversion() {
 	use frame_support::{dispatch::CallableCallFor, traits::IsSubType};
 	let call = RuntimeCall::Module3(module3::Call::<Runtime>::fail {});


### PR DESCRIPTION
Extends `GetCallMetadata` with `get_call_indices` to derive manually set indices to the calls in pallet. Makes it able to derive the name from an assigned call index.