### PR TITLE
Added procedural-core crate to export internal logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6929,6 +6929,7 @@ dependencies = [
  "expander",
  "frame-benchmarking",
  "frame-support",
+ "frame-support-procedural-core",
  "frame-support-procedural-tools",
  "frame-system",
  "itertools 0.11.0",
@@ -6944,6 +6945,17 @@ dependencies = [
  "sp-io 41.0.1",
  "sp-metadata-ir 0.11.0",
  "sp-runtime 42.0.0",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "frame-support-procedural-core"
+version = "34.0.0"
+dependencies = [
+ "cfg-expr",
+ "frame-support-procedural-tools",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
  "syn 2.0.98",
 ]
 
@@ -16213,6 +16225,7 @@ dependencies = [
  "frame-remote-externalities",
  "frame-support",
  "frame-support-procedural",
+ "frame-support-procedural-core",
  "frame-support-procedural-tools",
  "frame-support-procedural-tools-derive",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,6 +451,7 @@ members = [
 	"substrate/frame/sudo",
 	"substrate/frame/support",
 	"substrate/frame/support/procedural",
+	"substrate/frame/support/procedural/core",
 	"substrate/frame/support/procedural/tools",
 	"substrate/frame/support/procedural/tools/derive",
 	"substrate/frame/support/test",
@@ -820,6 +821,7 @@ frame-metadata-hash-extension = { path = "substrate/frame/metadata-hash-extensio
 frame-storage-access-test-runtime = { path = "substrate/utils/frame/storage-access-test-runtime", default-features = false }
 frame-support = { path = "substrate/frame/support", default-features = false }
 frame-support-procedural = { path = "substrate/frame/support/procedural", default-features = false }
+frame-support-procedural-core = { path = "substrate/frame/support/procedural/core", default-features = false }
 frame-support-procedural-tools = { path = "substrate/frame/support/procedural/tools", default-features = false }
 frame-support-procedural-tools-derive = { path = "substrate/frame/support/procedural/tools/derive", default-features = false }
 frame-support-test = { path = "substrate/frame/support/test" }

--- a/Plan.toml
+++ b/Plan.toml
@@ -330,6 +330,12 @@ bump = "major"
 reason = "changed"
 
 [[crate]]
+# substrate/frame/support/procedural/core
+name = "frame-support-procedural-core"
+from = "34.0.0"
+to = "34.0.0"
+
+[[crate]]
 # substrate/frame/support/procedural
 name = "frame-support-procedural"
 from = "33.0.1"

--- a/substrate/frame/support/procedural/Cargo.toml
+++ b/substrate/frame/support/procedural/Cargo.toml
@@ -26,9 +26,9 @@ cfg-expr = { workspace = true }
 derive-syn-parse = { workspace = true }
 docify = { workspace = true }
 expander = { workspace = true }
+frame-support-procedural-core.workspace = true
 frame-support-procedural-tools.default-features = true
 frame-support-procedural-tools.workspace = true
-frame-support-procedural-core.workspace = true
 itertools = { workspace = true }
 macro_magic = { features = ["proc_support"], workspace = true }
 proc-macro-warning = { workspace = true }

--- a/substrate/frame/support/procedural/Cargo.toml
+++ b/substrate/frame/support/procedural/Cargo.toml
@@ -28,6 +28,7 @@ docify = { workspace = true }
 expander = { workspace = true }
 frame-support-procedural-tools.default-features = true
 frame-support-procedural-tools.workspace = true
+frame-support-procedural-core.workspace = true
 itertools = { workspace = true }
 macro_magic = { features = ["proc_support"], workspace = true }
 proc-macro-warning = { workspace = true }

--- a/substrate/frame/support/procedural/core/Cargo.toml
+++ b/substrate/frame/support/procedural/core/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "frame-support-procedural-core"
+version = "34.0.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+description = "Core parser support for FRAME procedural macros."
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+cfg-expr = { workspace = true }
+frame-support-procedural-tools = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { features = ["full", "parsing"], workspace = true }

--- a/substrate/frame/support/procedural/core/src/construct_runtime/parse.rs
+++ b/substrate/frame/support/procedural/core/src/construct_runtime/parse.rs
@@ -96,22 +96,25 @@ impl Parse for RuntimeDeclaration {
 		let pallets_token = pallets.token;
 
 		match convert_pallets(pallets.content.inner.into_iter().collect())? {
-			PalletsConversion::Implicit(pallets) =>
-				Ok(RuntimeDeclaration::Implicit(ImplicitRuntimeDeclaration { pallets })),
-			PalletsConversion::Explicit(pallets) =>
+			PalletsConversion::Implicit(pallets) => {
+				Ok(RuntimeDeclaration::Implicit(ImplicitRuntimeDeclaration { pallets }))
+			},
+			PalletsConversion::Explicit(pallets) => {
 				Ok(RuntimeDeclaration::Explicit(ExplicitRuntimeDeclaration {
 					name,
 					where_section,
 					pallets,
 					pallets_token,
-				})),
-			PalletsConversion::ExplicitExpanded(pallets) =>
+				}))
+			},
+			PalletsConversion::ExplicitExpanded(pallets) => {
 				Ok(RuntimeDeclaration::ExplicitExpanded(ExplicitRuntimeDeclaration {
 					name,
 					where_section,
 					pallets,
 					pallets_token,
-				})),
+				}))
+			},
 		}
 	}
 }
@@ -233,13 +236,13 @@ impl Parse for PalletDeclaration {
 			let res = Some(input.parse()?);
 			let _: Token![>] = input.parse()?;
 			res
-		} else if !(input.peek(Token![::]) && input.peek3(token::Brace)) &&
-			!input.peek(keyword::expanded) &&
-			!input.peek(keyword::exclude_parts) &&
-			!input.peek(keyword::use_parts) &&
-			!input.peek(Token![=]) &&
-			!input.peek(Token![,]) &&
-			!input.is_empty()
+		} else if !(input.peek(Token![::]) && input.peek3(token::Brace))
+			&& !input.peek(keyword::expanded)
+			&& !input.peek(keyword::exclude_parts)
+			&& !input.peek(keyword::use_parts)
+			&& !input.peek(Token![=])
+			&& !input.peek(Token![,])
+			&& !input.is_empty()
 		{
 			return Err(input.error(
 				"Unexpected tokens, expected one of `::$ident` `::{`, `exclude_parts`, `use_parts`, `=`, `,`",
@@ -263,11 +266,11 @@ impl Parse for PalletDeclaration {
 			let mut parts = parse_pallet_parts(input)?;
 			parts.extend(extra_parts.into_iter());
 			Some(parts)
-		} else if !input.peek(keyword::exclude_parts) &&
-			!input.peek(keyword::use_parts) &&
-			!input.peek(Token![=]) &&
-			!input.peek(Token![,]) &&
-			!input.is_empty()
+		} else if !input.peek(keyword::exclude_parts)
+			&& !input.peek(keyword::use_parts)
+			&& !input.peek(Token![=])
+			&& !input.peek(Token![,])
+			&& !input.is_empty()
 		{
 			return Err(input.error(
 				"Unexpected tokens, expected one of `::{`, `exclude_parts`, `use_parts`, `=`, `,`",
@@ -332,10 +335,10 @@ impl Parse for PalletPath {
 			PalletPath { inner: Path { leading_colon: None, segments: Punctuated::new() } };
 
 		let lookahead = input.lookahead1();
-		if lookahead.peek(Token![crate]) ||
-			lookahead.peek(Token![self]) ||
-			lookahead.peek(Token![super]) ||
-			lookahead.peek(Ident)
+		if lookahead.peek(Token![crate])
+			|| lookahead.peek(Token![self])
+			|| lookahead.peek(Token![super])
+			|| lookahead.peek(Ident)
 		{
 			let ident = input.call(Ident::parse_any)?;
 			res.inner.segments.push(ident.into());
@@ -709,7 +712,7 @@ fn convert_pallets(pallets: Vec<PalletDeclaration>) -> syn::Result<PalletsConver
 
 			// Check parts are correctly specified
 			match &pallet.specified_parts {
-				SpecifiedParts::Exclude(parts) | SpecifiedParts::Use(parts) =>
+				SpecifiedParts::Exclude(parts) | SpecifiedParts::Use(parts) => {
 					for part in parts {
 						if !available_parts.contains(part.keyword.name()) {
 							let msg = format!(
@@ -727,7 +730,8 @@ fn convert_pallets(pallets: Vec<PalletDeclaration>) -> syn::Result<PalletsConver
 							);
 							return Err(syn::Error::new(part.keyword.span(), msg));
 						}
-					},
+					}
+				},
 				SpecifiedParts::All => (),
 			}
 

--- a/substrate/frame/support/procedural/core/src/construct_runtime/parse.rs
+++ b/substrate/frame/support/procedural/core/src/construct_runtime/parse.rs
@@ -96,25 +96,22 @@ impl Parse for RuntimeDeclaration {
 		let pallets_token = pallets.token;
 
 		match convert_pallets(pallets.content.inner.into_iter().collect())? {
-			PalletsConversion::Implicit(pallets) => {
-				Ok(RuntimeDeclaration::Implicit(ImplicitRuntimeDeclaration { pallets }))
-			},
-			PalletsConversion::Explicit(pallets) => {
+			PalletsConversion::Implicit(pallets) =>
+				Ok(RuntimeDeclaration::Implicit(ImplicitRuntimeDeclaration { pallets })),
+			PalletsConversion::Explicit(pallets) =>
 				Ok(RuntimeDeclaration::Explicit(ExplicitRuntimeDeclaration {
 					name,
 					where_section,
 					pallets,
 					pallets_token,
-				}))
-			},
-			PalletsConversion::ExplicitExpanded(pallets) => {
+				})),
+			PalletsConversion::ExplicitExpanded(pallets) =>
 				Ok(RuntimeDeclaration::ExplicitExpanded(ExplicitRuntimeDeclaration {
 					name,
 					where_section,
 					pallets,
 					pallets_token,
-				}))
-			},
+				})),
 		}
 	}
 }
@@ -236,13 +233,13 @@ impl Parse for PalletDeclaration {
 			let res = Some(input.parse()?);
 			let _: Token![>] = input.parse()?;
 			res
-		} else if !(input.peek(Token![::]) && input.peek3(token::Brace))
-			&& !input.peek(keyword::expanded)
-			&& !input.peek(keyword::exclude_parts)
-			&& !input.peek(keyword::use_parts)
-			&& !input.peek(Token![=])
-			&& !input.peek(Token![,])
-			&& !input.is_empty()
+		} else if !(input.peek(Token![::]) && input.peek3(token::Brace)) &&
+			!input.peek(keyword::expanded) &&
+			!input.peek(keyword::exclude_parts) &&
+			!input.peek(keyword::use_parts) &&
+			!input.peek(Token![=]) &&
+			!input.peek(Token![,]) &&
+			!input.is_empty()
 		{
 			return Err(input.error(
 				"Unexpected tokens, expected one of `::$ident` `::{`, `exclude_parts`, `use_parts`, `=`, `,`",
@@ -266,11 +263,11 @@ impl Parse for PalletDeclaration {
 			let mut parts = parse_pallet_parts(input)?;
 			parts.extend(extra_parts.into_iter());
 			Some(parts)
-		} else if !input.peek(keyword::exclude_parts)
-			&& !input.peek(keyword::use_parts)
-			&& !input.peek(Token![=])
-			&& !input.peek(Token![,])
-			&& !input.is_empty()
+		} else if !input.peek(keyword::exclude_parts) &&
+			!input.peek(keyword::use_parts) &&
+			!input.peek(Token![=]) &&
+			!input.peek(Token![,]) &&
+			!input.is_empty()
 		{
 			return Err(input.error(
 				"Unexpected tokens, expected one of `::{`, `exclude_parts`, `use_parts`, `=`, `,`",
@@ -335,10 +332,10 @@ impl Parse for PalletPath {
 			PalletPath { inner: Path { leading_colon: None, segments: Punctuated::new() } };
 
 		let lookahead = input.lookahead1();
-		if lookahead.peek(Token![crate])
-			|| lookahead.peek(Token![self])
-			|| lookahead.peek(Token![super])
-			|| lookahead.peek(Ident)
+		if lookahead.peek(Token![crate]) ||
+			lookahead.peek(Token![self]) ||
+			lookahead.peek(Token![super]) ||
+			lookahead.peek(Ident)
 		{
 			let ident = input.call(Ident::parse_any)?;
 			res.inner.segments.push(ident.into());
@@ -712,7 +709,7 @@ fn convert_pallets(pallets: Vec<PalletDeclaration>) -> syn::Result<PalletsConver
 
 			// Check parts are correctly specified
 			match &pallet.specified_parts {
-				SpecifiedParts::Exclude(parts) | SpecifiedParts::Use(parts) => {
+				SpecifiedParts::Exclude(parts) | SpecifiedParts::Use(parts) =>
 					for part in parts {
 						if !available_parts.contains(part.keyword.name()) {
 							let msg = format!(
@@ -730,8 +727,7 @@ fn convert_pallets(pallets: Vec<PalletDeclaration>) -> syn::Result<PalletsConver
 							);
 							return Err(syn::Error::new(part.keyword.span(), msg));
 						}
-					}
-				},
+					},
 				SpecifiedParts::All => (),
 			}
 

--- a/substrate/frame/support/procedural/core/src/lib.rs
+++ b/substrate/frame/support/procedural/core/src/lib.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Core parser support for FRAME procedural macros.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub mod construct_runtime {
+	pub mod parse;
+}

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/composite_helper.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/composite_helper.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
-use crate::construct_runtime::parse::PalletPath;
+use frame_support_procedural_core::construct_runtime::parse::PalletPath;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
-use crate::construct_runtime::{parse::PalletPath, Pallet};
+use frame_support_procedural_core::construct_runtime::parse::{Pallet, PalletPath};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Ident;

--- a/substrate/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/mod.rs
@@ -209,15 +209,16 @@
 //! expose.
 
 pub(crate) mod expand;
-pub(crate) mod parse;
 
 use crate::pallet::parse::helper::two128_str;
 use cfg_expr::Predicate;
+use frame_support_procedural_core::construct_runtime::parse::{
+	ExplicitRuntimeDeclaration, ImplicitRuntimeDeclaration, Pallet, RuntimeDeclaration,
+};
 use frame_support_procedural_tools::{
 	generate_access_from_frame_or_crate, generate_crate_access, generate_hidden_includes,
 };
 use itertools::Itertools;
-use parse::{ExplicitRuntimeDeclaration, ImplicitRuntimeDeclaration, Pallet, RuntimeDeclaration};
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;

--- a/substrate/frame/support/procedural/src/runtime/parse/mod.rs
+++ b/substrate/frame/support/procedural/src/runtime/parse/mod.rs
@@ -21,7 +21,7 @@ pub mod pallet_decl;
 pub mod runtime_struct;
 pub mod runtime_types;
 
-use crate::construct_runtime::parse::Pallet;
+use frame_support_procedural_core::construct_runtime::parse::Pallet;
 use pallet_decl::PalletDeclaration;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::ToTokens;
@@ -202,7 +202,7 @@ impl Def {
 						pallet_decls.push(pallet_decl);
 					},
 					syn::Type::TraitObject(syn::TypeTraitObject { bounds, .. }) => {
-						let pallet = Pallet::try_from(
+						let pallet = pallet::pallet_from_item(
 							item.span(),
 							&pallet_item,
 							pallet_index,

--- a/substrate/frame/support/procedural/src/runtime/parse/pallet.rs
+++ b/substrate/frame/support/procedural/src/runtime/parse/pallet.rs
@@ -15,95 +15,93 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-	construct_runtime::parse::{Pallet, PalletPart, PalletPartKeyword, PalletPath},
-	runtime::parse::PalletDeclaration,
+use crate::runtime::parse::PalletDeclaration;
+use frame_support_procedural_core::construct_runtime::parse::{
+	Pallet, PalletPart, PalletPartKeyword, PalletPath,
 };
 use frame_support_procedural_tools::get_doc_literals;
 use quote::ToTokens;
 use syn::{punctuated::Punctuated, spanned::Spanned, token, Error};
 
-impl Pallet {
-	pub fn try_from(
-		attr_span: proc_macro2::Span,
-		item: &syn::ItemType,
-		pallet_index: u8,
-		disable_call: bool,
-		disable_unsigned: bool,
-		bounds: &Punctuated<syn::TypeParamBound, token::Plus>,
-	) -> syn::Result<Self> {
-		let name = item.ident.clone();
+pub fn pallet_from_item(
+	attr_span: proc_macro2::Span,
+	item: &syn::ItemType,
+	pallet_index: u8,
+	disable_call: bool,
+	disable_unsigned: bool,
+	bounds: &Punctuated<syn::TypeParamBound, token::Plus>,
+) -> syn::Result<Pallet> {
+	let name = item.ident.clone();
 
-		let mut pallet_path = None;
-		let mut pallet_parts = vec![];
+	let mut pallet_path = None;
+	let mut pallet_parts = vec![];
 
-		for (index, bound) in bounds.into_iter().enumerate() {
-			if let syn::TypeParamBound::Trait(syn::TraitBound { path, .. }) = bound {
-				if index == 0 {
-					pallet_path = Some(PalletPath { inner: path.clone() });
-				} else {
-					let pallet_part = syn::parse2::<PalletPart>(bound.into_token_stream())?;
-					pallet_parts.push(pallet_part);
-				}
+	for (index, bound) in bounds.into_iter().enumerate() {
+		if let syn::TypeParamBound::Trait(syn::TraitBound { path, .. }) = bound {
+			if index == 0 {
+				pallet_path = Some(PalletPath { inner: path.clone() });
 			} else {
-				return Err(Error::new(
-					attr_span,
-					"Invalid pallet declaration, expected a path or a trait object",
-				));
-			};
-		}
-
-		let mut path = pallet_path.ok_or(Error::new(
-			attr_span,
-			"Invalid pallet declaration, expected a path or a trait object",
-		))?;
-
-		let PalletDeclaration { path: inner, instance, .. } =
-			PalletDeclaration::try_from(attr_span, item, &path.inner)?;
-
-		path = PalletPath { inner };
-
-		pallet_parts = pallet_parts
-			.into_iter()
-			.filter(|part| {
-				if let (true, &PalletPartKeyword::Call(_)) = (disable_call, &part.keyword) {
-					false
-				} else if let (true, &PalletPartKeyword::ValidateUnsigned(_)) =
-					(disable_unsigned, &part.keyword)
-				{
-					false
-				} else {
-					true
-				}
-			})
-			.collect();
-
-		let cfg_pattern = item
-			.attrs
-			.iter()
-			.filter(|attr| attr.path().segments.first().map_or(false, |s| s.ident == "cfg"))
-			.map(|attr| {
-				attr.parse_args_with(|input: syn::parse::ParseStream| {
-					let input = input.parse::<proc_macro2::TokenStream>()?;
-					cfg_expr::Expression::parse(&input.to_string())
-						.map_err(|e| syn::Error::new(attr.span(), e.to_string()))
-				})
-			})
-			.collect::<syn::Result<Vec<_>>>()?;
-
-		let docs = get_doc_literals(&item.attrs);
-
-		Ok(Pallet {
-			is_expanded: true,
-			name,
-			index: pallet_index,
-			path,
-			instance,
-			cfg_pattern,
-			pallet_parts,
-			docs,
-		})
+				let pallet_part = syn::parse2::<PalletPart>(bound.into_token_stream())?;
+				pallet_parts.push(pallet_part);
+			}
+		} else {
+			return Err(Error::new(
+				attr_span,
+				"Invalid pallet declaration, expected a path or a trait object",
+			));
+		};
 	}
+
+	let mut path = pallet_path.ok_or(Error::new(
+		attr_span,
+		"Invalid pallet declaration, expected a path or a trait object",
+	))?;
+
+	let PalletDeclaration { path: inner, instance, .. } =
+		PalletDeclaration::try_from(attr_span, item, &path.inner)?;
+
+	path = PalletPath { inner };
+
+	pallet_parts = pallet_parts
+		.into_iter()
+		.filter(|part| {
+			if let (true, &PalletPartKeyword::Call(_)) = (disable_call, &part.keyword) {
+				false
+			} else if let (true, &PalletPartKeyword::ValidateUnsigned(_)) =
+				(disable_unsigned, &part.keyword)
+			{
+				false
+			} else {
+				true
+			}
+		})
+		.collect();
+
+	let cfg_pattern = item
+		.attrs
+		.iter()
+		.filter(|attr| attr.path().segments.first().map_or(false, |s| s.ident == "cfg"))
+		.map(|attr| {
+			attr.parse_args_with(|input: syn::parse::ParseStream| {
+				let input = input.parse::<proc_macro2::TokenStream>()?;
+				cfg_expr::Expression::parse(&input.to_string())
+					.map_err(|e| syn::Error::new(attr.span(), e.to_string()))
+			})
+		})
+		.collect::<syn::Result<Vec<_>>>()?;
+
+	let docs = get_doc_literals(&item.attrs);
+
+	Ok(Pallet {
+		is_expanded: true,
+		name,
+		index: pallet_index,
+		path,
+		instance,
+		cfg_pattern,
+		pallet_parts,
+		docs,
+	})
 }
 
 #[test]
@@ -120,7 +118,7 @@ fn pallet_parsing_works() {
 
 	let index = 0;
 	let pallet =
-		Pallet::try_from(proc_macro2::Span::call_site(), &item, index, false, false, &bounds)
+		pallet_from_item(proc_macro2::Span::call_site(), &item, index, false, false, &bounds)
 			.unwrap();
 
 	assert_eq!(pallet.name.to_string(), "System");
@@ -143,7 +141,7 @@ fn pallet_parsing_works_with_instance() {
 
 	let index = 0;
 	let pallet =
-		Pallet::try_from(proc_macro2::Span::call_site(), &item, index, false, false, &bounds)
+		pallet_from_item(proc_macro2::Span::call_site(), &item, index, false, false, &bounds)
 			.unwrap();
 
 	assert_eq!(pallet.name.to_string(), "System");
@@ -166,7 +164,7 @@ fn pallet_parsing_works_with_pallet() {
 
 	let index = 0;
 	let pallet =
-		Pallet::try_from(proc_macro2::Span::call_site(), &item, index, false, false, &bounds)
+		pallet_from_item(proc_macro2::Span::call_site(), &item, index, false, false, &bounds)
 			.unwrap();
 
 	assert_eq!(pallet.name.to_string(), "System");
@@ -189,7 +187,7 @@ fn pallet_parsing_works_with_instance_and_pallet() {
 
 	let index = 0;
 	let pallet =
-		Pallet::try_from(proc_macro2::Span::call_site(), &item, index, false, false, &bounds)
+		pallet_from_item(proc_macro2::Span::call_site(), &item, index, false, false, &bounds)
 			.unwrap();
 
 	assert_eq!(pallet.name.to_string(), "System");

--- a/umbrella/Cargo.toml
+++ b/umbrella/Cargo.toml
@@ -580,6 +580,7 @@ runtime-full = [
 	"frame-metadata-hash-extension",
 	"frame-support",
 	"frame-support-procedural",
+	"frame-support-procedural-core",
 	"frame-support-procedural-tools-derive",
 	"frame-system",
 	"frame-system-benchmarking",
@@ -779,6 +780,7 @@ runtime = [
 	"frame-metadata-hash-extension",
 	"frame-support",
 	"frame-support-procedural",
+	"frame-support-procedural-core",
 	"frame-support-procedural-tools-derive",
 	"frame-system",
 	"frame-system-benchmarking",
@@ -1194,6 +1196,11 @@ path = "../substrate/frame/support"
 default-features = false
 optional = true
 path = "../substrate/frame/support/procedural"
+
+[dependencies.frame-support-procedural-core]
+default-features = false
+optional = true
+path = "../substrate/frame/support/procedural/core"
 
 [dependencies.frame-support-procedural-tools-derive]
 default-features = false

--- a/umbrella/src/lib.rs
+++ b/umbrella/src/lib.rs
@@ -264,6 +264,10 @@ pub use frame_support;
 #[cfg(feature = "frame-support-procedural")]
 pub use frame_support_procedural;
 
+/// Core parser support for FRAME procedural macros.
+#[cfg(feature = "frame-support-procedural-core")]
+pub use frame_support_procedural_core;
+
 /// Proc macro helpers for procedural macros.
 #[cfg(feature = "frame-support-procedural-tools")]
 pub use frame_support_procedural_tools;


### PR DESCRIPTION
## Summary

This PR moves the `construct_runtime` parser API out of the `frame-support-procedural` proc-macro crate and into a new normal library crate, `frame-support-procedural-core`.

The proc-macro crate remains the macro expansion layer and now imports the shared parser types from `frame-support-procedural-core`. This gives downstream tooling a stable Rust library surface for parsing `construct_runtime!` without needing to vendor or depend directly on a forked proc-macro implementation.

Companion Subtensor cleanup removes the local `support/procedural-fork` copy and updates the linting crate to depend on `frame-support-procedural-core` instead.

## Changes

- Add `frame-support-procedural-core` as a workspace crate.
- Move `construct_runtime::parse` into the new core crate.
- Update `frame-support-procedural` to use the parser types from `frame-support-procedural-core`.
- Keep macro behavior unchanged: `frame-support-procedural` is still responsible for macro expansion.
- Add the new crate to workspace metadata and umbrella exports.
- Update Subtensor linting to use `frame_support_procedural_core::construct_runtime::parse`.
- Remove Subtensor's vendored `support/procedural-fork`.