### PR TITLE
Use GRANDPA hard forks as warp sync checkpoints

### DIFF
--- a/substrate/client/consensus/grandpa/src/authorities.rs
+++ b/substrate/client/consensus/grandpa/src/authorities.rs
@@ -780,15 +780,34 @@ impl<N: Ord + Clone> AuthoritySetChanges<N> {
 		Some(self.0[idx..].iter())
 	}
 
-	/// Returns recorded authority changes after a trusted checkpoint. Unlike [`Self::iter_from`],
-	/// this intentionally permits an incomplete historical prefix because the caller already knows
-	/// the authority set at `set_id` and `block_number`.
-	pub(crate) fn iter_after_known(
+	/// Returns a contiguous sequence of recorded authority changes after a trusted checkpoint.
+	/// Unlike [`Self::iter_from`], this intentionally permits an incomplete historical prefix
+	/// because the caller knows the checkpoint at `block_number`. `expected_set_id` is the first
+	/// authority set whose terminal change record may follow that checkpoint. Returns `None` when
+	/// the retained suffix skips an authority set.
+	pub(crate) fn contiguous_changes_after(
 		&self,
-		set_id: SetId,
+		expected_set_id: SetId,
 		block_number: N,
-	) -> impl Iterator<Item = &(u64, N)> {
-		self.0.iter().filter(move |(id, block)| *id > set_id && *block > block_number)
+	) -> Option<Vec<&(u64, N)>> {
+		let minimum_set_id = expected_set_id;
+		let mut expected_set_id = Some(expected_set_id);
+		let mut changes = Vec::new();
+
+		for change in self
+			.0
+			.iter()
+			.filter(|(id, block)| *id >= minimum_set_id && *block > block_number)
+		{
+			if expected_set_id != Some(change.0) {
+				return None
+			}
+
+			expected_set_id = change.0.checked_add(1);
+			changes.push(change);
+		}
+
+		Some(changes)
 	}
 }
 
@@ -1757,5 +1776,27 @@ mod tests {
 		assert_eq!(0, authority_set_changes.iter_from(121).unwrap().count());
 
 		assert_eq!(0, authority_set_changes.iter_from(200).unwrap().count());
+	}
+
+	#[test]
+	fn contiguous_changes_after_ignores_obsolete_history() {
+		let authority_set_changes =
+			AuthoritySetChanges::from(vec![(3, 30), (0, 35), (4, 40), (5, 50)]);
+
+		assert_eq!(
+			Some(vec![(3, 30), (4, 40), (5, 50)]),
+			authority_set_changes
+				.contiguous_changes_after(3, 20)
+				.map(|changes| changes.into_iter().cloned().collect()),
+		);
+	}
+
+	#[test]
+	fn contiguous_changes_after_rejects_leading_and_internal_gaps() {
+		let leading_gap = AuthoritySetChanges::from(vec![(4, 40), (5, 50)]);
+		assert!(leading_gap.contiguous_changes_after(3, 20).is_none());
+
+		let internal_gap = AuthoritySetChanges::from(vec![(3, 30), (5, 50)]);
+		assert!(internal_gap.contiguous_changes_after(3, 20).is_none());
 	}
 }

--- a/substrate/client/consensus/grandpa/src/authorities.rs
+++ b/substrate/client/consensus/grandpa/src/authorities.rs
@@ -779,6 +779,17 @@ impl<N: Ord + Clone> AuthoritySetChanges<N> {
 
 		Some(self.0[idx..].iter())
 	}
+
+	/// Returns recorded authority changes after a trusted checkpoint. Unlike [`Self::iter_from`],
+	/// this intentionally permits an incomplete historical prefix because the caller already knows
+	/// the authority set at `set_id` and `block_number`.
+	pub(crate) fn iter_after_known(
+		&self,
+		set_id: SetId,
+		block_number: N,
+	) -> impl Iterator<Item = &(u64, N)> {
+		self.0.iter().filter(move |(id, block)| *id > set_id && *block > block_number)
+	}
 }
 
 #[cfg(test)]

--- a/substrate/client/consensus/grandpa/src/warp_proof.rs
+++ b/substrate/client/consensus/grandpa/src/warp_proof.rs
@@ -118,8 +118,12 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 		let mut proofs_encoded_len = 0;
 		let mut proof_limit_reached = false;
 
-		let set_change_blocks =
-			hard_forks.warp_sync_change_blocks(begin_number, finalized_number, set_changes)?;
+		let set_change_blocks = hard_forks.warp_sync_change_blocks(
+			begin_number,
+			finalized_number,
+			set_changes,
+			|hash, number| Ok(blockchain.hash(number)?.as_ref() == Some(hash)),
+		)?;
 
 		for last_block in set_change_blocks {
 			let hash = match blockchain.block_hash_from_id(&BlockId::Number(*last_block))? {
@@ -330,6 +334,7 @@ impl<Block: BlockT> HardForks<Block> {
 		begin: NumberFor<Block>,
 		finalized: NumberFor<Block>,
 		set_changes: &'a AuthoritySetChanges<NumberFor<Block>>,
+		mut is_canonical: impl FnMut(&Block::Hash, NumberFor<Block>) -> Result<bool, Error>,
 	) -> Result<Vec<&'a NumberFor<Block>>, Error> {
 		let HardForks::AuthoritySetHardForks { hard_forks } = self else {
 			return set_changes
@@ -338,13 +343,13 @@ impl<Block: BlockT> HardForks<Block> {
 				.ok_or(Error::MissingData);
 		};
 
-		let mut checkpoints = hard_forks
-			.iter()
-			.map(|((_, number), (set_id, _))| (number, *set_id))
-			.filter(|(number, _)| **number <= finalized)
-			.collect::<Vec<_>>();
+		let mut checkpoints = Vec::new();
+		for ((hash, number), (set_id, _)) in hard_forks {
+			if *number <= finalized && is_canonical(hash, *number)? {
+				checkpoints.push((number, *set_id));
+			}
+		}
 		checkpoints.sort_unstable_by_key(|(number, _)| *number);
-		checkpoints.dedup_by_key(|(number, _)| *number);
 
 		let Some((last_checkpoint, last_checkpoint_set_id)) = checkpoints.last().copied() else {
 			return set_changes
@@ -358,7 +363,7 @@ impl<Block: BlockT> HardForks<Block> {
 			.map(|(block, _)| block)
 			.filter(|checkpoint| **checkpoint > begin)
 			.collect::<Vec<_>>();
-		let suffix_begin = if begin > *last_checkpoint { begin } else { last_checkpoint.clone() };
+		let suffix_begin = if begin > *last_checkpoint { begin } else { *last_checkpoint };
 		blocks.extend(
 			set_changes
 				.iter_after_known(last_checkpoint_set_id, suffix_begin)
@@ -567,6 +572,19 @@ mod tests {
 		let warp_sync_proof =
 			WarpSyncProof::generate(&*backend, genesis_hash, &authority_set_changes, &hard_forks)
 				.unwrap();
+		let legacy_proof = warp_sync_proof.encode();
+
+		// Reinitializing the starting set ID is Subtensor mainnet's existing mode. Supplying that
+		// mode must not alter which proof fragments the server generates.
+		let reinitialized_set_id = HardForks::new_initial_set_id(3);
+		let reinitialized_proof = WarpSyncProof::generate(
+			&*backend,
+			genesis_hash,
+			&authority_set_changes,
+			&reinitialized_set_id,
+		)
+		.unwrap();
+		assert_eq!(reinitialized_proof.encode(), legacy_proof);
 
 		// verifying the proof should yield the last set id and authorities
 		let (new_set_id, new_authorities) =
@@ -584,13 +602,23 @@ mod tests {
 		// and verification. This allows a chain to skip historical transitions that cannot produce
 		// a valid warp fragment without changing the proof's wire format.
 		let hard_fork = hard_fork.expect("block 50 is an authority-set transition");
+		let noncanonical_hard_fork = AuthoritySetHardFork {
+			set_id: 99,
+			block: (Default::default(), hard_fork.block.1),
+			authorities: hard_fork.authorities.clone(),
+			last_finalized: None,
+		};
 		let future_hard_fork = AuthoritySetHardFork {
 			set_id: 10,
 			block: (Default::default(), 110),
 			authorities: hard_fork.authorities.clone(),
 			last_finalized: None,
 		};
-		let hard_forks = HardForks::new_hard_forked_authorities(vec![hard_fork, future_hard_fork]);
+		let hard_forks = HardForks::new_hard_forked_authorities(vec![
+			hard_fork,
+			noncanonical_hard_fork,
+			future_hard_fork,
+		]);
 		let poisoned_authority_set_changes = AuthoritySetChanges::from({
 			// Model a node that warp-synced to the checkpoint and therefore has no set-0 prefix.
 			let mut changes = authority_set_change_records
@@ -610,6 +638,14 @@ mod tests {
 		)
 		.unwrap();
 		assert_eq!(*warp_sync_proof.proofs[0].header.number(), 50);
+		assert_eq!(
+			warp_sync_proof
+				.proofs
+				.iter()
+				.filter(|proof| *proof.header.number() == 50)
+				.count(),
+			1,
+		);
 
 		let (new_set_id, new_authorities) =
 			warp_sync_proof.verify(0, genesis_authorities, &hard_forks).unwrap();

--- a/substrate/client/consensus/grandpa/src/warp_proof.rs
+++ b/substrate/client/consensus/grandpa/src/warp_proof.rs
@@ -85,6 +85,7 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 		backend: &Backend,
 		begin: Block::Hash,
 		set_changes: &AuthoritySetChanges<NumberFor<Block>>,
+		hard_forks: &HardForks<Block>,
 	) -> Result<WarpSyncProof<Block>, Error>
 	where
 		Backend: ClientBackend<Block>,
@@ -96,7 +97,8 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 			.block_number_from_id(&BlockId::Hash(begin))?
 			.ok_or_else(|| Error::InvalidRequest("Missing start block".to_string()))?;
 
-		if begin_number > blockchain.info().finalized_number {
+		let finalized_number = blockchain.info().finalized_number;
+		if begin_number > finalized_number {
 			return Err(Error::InvalidRequest("Start block is not finalized".to_string()))
 		}
 
@@ -116,9 +118,10 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 		let mut proofs_encoded_len = 0;
 		let mut proof_limit_reached = false;
 
-		let set_changes = set_changes.iter_from(begin_number).ok_or(Error::MissingData)?;
+		let set_change_blocks =
+			hard_forks.warp_sync_change_blocks(begin_number, finalized_number, set_changes)?;
 
-		for (_, last_block) in set_changes {
+		for last_block in set_change_blocks {
 			let hash = match blockchain.block_hash_from_id(&BlockId::Number(*last_block))? {
 				Some(hash) => hash,
 				None => {
@@ -318,6 +321,51 @@ impl<Block: BlockT> HardForks<Block> {
 			None
 		}
 	}
+
+	/// Return the authority-change blocks to include in a warp proof. Hard-fork blocks are trusted
+	/// checkpoints: they replace older history that cannot form a valid proof, while normal
+	/// recorded changes after the last checkpoint are retained.
+	fn warp_sync_change_blocks<'a>(
+		&'a self,
+		begin: NumberFor<Block>,
+		finalized: NumberFor<Block>,
+		set_changes: &'a AuthoritySetChanges<NumberFor<Block>>,
+	) -> Result<Vec<&'a NumberFor<Block>>, Error> {
+		let HardForks::AuthoritySetHardForks { hard_forks } = self else {
+			return set_changes
+				.iter_from(begin)
+				.map(|changes| changes.map(|(_, block)| block).collect())
+				.ok_or(Error::MissingData);
+		};
+
+		let mut checkpoints = hard_forks
+			.iter()
+			.map(|((_, number), (set_id, _))| (number, *set_id))
+			.filter(|(number, _)| **number <= finalized)
+			.collect::<Vec<_>>();
+		checkpoints.sort_unstable_by_key(|(number, _)| *number);
+		checkpoints.dedup_by_key(|(number, _)| *number);
+
+		let Some((last_checkpoint, last_checkpoint_set_id)) = checkpoints.last().copied() else {
+			return set_changes
+				.iter_from(begin)
+				.map(|changes| changes.map(|(_, block)| block).collect())
+				.ok_or(Error::MissingData);
+		};
+
+		let mut blocks = checkpoints
+			.into_iter()
+			.map(|(block, _)| block)
+			.filter(|checkpoint| **checkpoint > begin)
+			.collect::<Vec<_>>();
+		let suffix_begin = if begin > *last_checkpoint { begin } else { last_checkpoint.clone() };
+		blocks.extend(
+			set_changes
+				.iter_after_known(last_checkpoint_set_id, suffix_begin)
+				.map(|(_, block)| block),
+		);
+		Ok(blocks)
+	}
 }
 
 impl<Block: BlockT, Backend: ClientBackend<Block>> NetworkProvider<Block, Backend>
@@ -347,6 +395,7 @@ where
 			&*self.backend,
 			start,
 			&self.authority_set.authority_set_changes(),
+			&self.hard_forks,
 		)
 		.map_err(Box::new)?;
 		Ok(EncodedProof(proof.encode()))
@@ -387,7 +436,7 @@ where
 #[cfg(test)]
 mod tests {
 	use super::{HardForks, WarpSyncProof};
-	use crate::{AuthoritySetChanges, GrandpaJustification};
+	use crate::{AuthoritySetChanges, AuthoritySetHardFork, GrandpaJustification};
 	use codec::Encode;
 	use rand::prelude::*;
 	use sc_block_builder::BlockBuilderBuilder;
@@ -395,6 +444,7 @@ mod tests {
 	use sp_consensus::BlockOrigin;
 	use sp_consensus_grandpa::GRANDPA_ENGINE_ID;
 	use sp_keyring::Ed25519Keyring;
+	use sp_runtime::traits::Header as _;
 	use std::sync::Arc;
 	use substrate_test_runtime_client::{
 		BlockBuilderExt, ClientBlockImportExt, ClientExt, DefaultTestClientBuilderExt,
@@ -414,6 +464,7 @@ mod tests {
 		let mut current_authorities = vec![Ed25519Keyring::Alice];
 		let mut current_set_id = 0;
 		let mut authority_set_changes = Vec::new();
+		let mut hard_fork = None;
 
 		for n in 1..=100 {
 			let mut builder = BlockBuilderBuilder::new(&*client)
@@ -483,6 +534,18 @@ mod tests {
 
 				let justification = GrandpaJustification::from_commit(&client, 42, commit).unwrap();
 
+				if n == 50 {
+					hard_fork = Some(AuthoritySetHardFork {
+						set_id: current_set_id,
+						block: (target_hash, target_number),
+						authorities: current_authorities
+							.iter()
+							.map(|keyring| (keyring.public().into(), 1))
+							.collect(),
+						last_finalized: None,
+					});
+				}
+
 				client
 					.finalize_block(target_hash, Some((GRANDPA_ENGINE_ID, justification.encode())))
 					.unwrap();
@@ -494,24 +557,62 @@ mod tests {
 			}
 		}
 
-		let authority_set_changes = AuthoritySetChanges::from(authority_set_changes);
+		let authority_set_change_records = authority_set_changes;
+		let authority_set_changes = AuthoritySetChanges::from(authority_set_change_records.clone());
 
 		// generate a warp sync proof
 		let genesis_hash = client.hash(0).unwrap().unwrap();
 
+		let hard_forks = HardForks::new_hard_forked_authorities(vec![]);
 		let warp_sync_proof =
-			WarpSyncProof::generate(&*backend, genesis_hash, &authority_set_changes).unwrap();
+			WarpSyncProof::generate(&*backend, genesis_hash, &authority_set_changes, &hard_forks)
+				.unwrap();
 
 		// verifying the proof should yield the last set id and authorities
-		let hard_forks = HardForks::new_hard_forked_authorities(vec![]);
 		let (new_set_id, new_authorities) =
-			warp_sync_proof.verify(0, genesis_authorities, &hard_forks).unwrap();
+			warp_sync_proof.verify(0, genesis_authorities.clone(), &hard_forks).unwrap();
 
 		let expected_authorities = current_authorities
 			.iter()
 			.map(|keyring| (keyring.public().into(), 1))
 			.collect::<Vec<_>>();
 
+		assert_eq!(new_set_id, current_set_id);
+		assert_eq!(new_authorities, expected_authorities);
+
+		// A trusted checkpoint replaces earlier authority-set history during both proof generation
+		// and verification. This allows a chain to skip historical transitions that cannot produce
+		// a valid warp fragment without changing the proof's wire format.
+		let hard_fork = hard_fork.expect("block 50 is an authority-set transition");
+		let future_hard_fork = AuthoritySetHardFork {
+			set_id: 10,
+			block: (Default::default(), 110),
+			authorities: hard_fork.authorities.clone(),
+			last_finalized: None,
+		};
+		let hard_forks = HardForks::new_hard_forked_authorities(vec![hard_fork, future_hard_fork]);
+		let poisoned_authority_set_changes = AuthoritySetChanges::from({
+			// Model a node that warp-synced to the checkpoint and therefore has no set-0 prefix.
+			let mut changes = authority_set_change_records
+				.into_iter()
+				.filter(|(set_id, _)| *set_id >= 5)
+				.collect::<Vec<_>>();
+			// Also model the bad lower-set-id record present in the affected chain database.
+			changes.push((0, 55));
+			changes.sort_unstable_by_key(|(_, block)| *block);
+			changes
+		});
+		let warp_sync_proof = WarpSyncProof::generate(
+			&*backend,
+			genesis_hash,
+			&poisoned_authority_set_changes,
+			&hard_forks,
+		)
+		.unwrap();
+		assert_eq!(*warp_sync_proof.proofs[0].header.number(), 50);
+
+		let (new_set_id, new_authorities) =
+			warp_sync_proof.verify(0, genesis_authorities, &hard_forks).unwrap();
 		assert_eq!(new_set_id, current_set_id);
 		assert_eq!(new_authorities, expected_authorities);
 	}

--- a/substrate/client/consensus/grandpa/src/warp_proof.rs
+++ b/substrate/client/consensus/grandpa/src/warp_proof.rs
@@ -63,7 +63,8 @@ pub(super) const MAX_WARP_SYNC_PROOF_SIZE: usize = 8 * 1024 * 1024;
 #[derive(Decode, Encode, Debug)]
 pub struct WarpSyncFragment<Block: BlockT> {
 	/// The last block that the given authority set finalized. This block should contain a digest
-	/// signaling an authority set change from which we can fetch the next authority set.
+	/// signaling an authority set change from which we can fetch the next authority set, unless it
+	/// is an explicitly configured off-chain authority-set checkpoint.
 	pub header: Block::Header,
 	/// A justification for the header above which proves its finality. In order to validate it the
 	/// verifier must be aware of the authorities and set id for which the justification refers to.
@@ -78,6 +79,34 @@ pub struct WarpSyncProof<Block: BlockT> {
 }
 
 impl<Block: BlockT> WarpSyncProof<Block> {
+	fn push_fragment<Blockchain>(
+		blockchain: &Blockchain,
+		header: Block::Header,
+		proofs: &mut Vec<WarpSyncFragment<Block>>,
+		proofs_encoded_len: &mut usize,
+	) -> Result<bool, Error>
+	where
+		Blockchain: BlockchainBackend<Block>,
+	{
+		let justification = blockchain
+			.justifications(header.hash())?
+			.and_then(|just| just.into_justification(GRANDPA_ENGINE_ID))
+			.ok_or(Error::MissingData)?;
+		let justification = GrandpaJustification::<Block>::decode_all(&mut &justification[..])?;
+		let proof = WarpSyncFragment { header, justification };
+		let proof_size = proof.encoded_size();
+
+		// Leave room for the encoded `Vec` length and `is_finished` flag, which are not part of
+		// the fragment sizes accumulated here.
+		if *proofs_encoded_len + proof_size >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+			return Ok(false)
+		}
+
+		*proofs_encoded_len += proof_size;
+		proofs.push(proof);
+		Ok(true)
+	}
+
 	/// Generates a warp sync proof starting at the given block. It will generate authority set
 	/// change proofs for all changes that happened from `begin` until the current authority set
 	/// (capped by MAX_WARP_SYNC_PROOF_SIZE).
@@ -114,18 +143,54 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 			))
 		}
 
+		let mut latest_checkpoint = None;
+		if let Some(checkpoints) = hard_forks.authority_set_checkpoints() {
+			for ((hash, number), (set_id, _)) in checkpoints {
+				if *number <= begin_number || *number > finalized_number {
+					continue
+				}
+				if latest_checkpoint
+					.as_ref()
+					.is_some_and(|(_, latest_number, _)| number <= *latest_number)
+				{
+					continue
+				}
+				if blockchain.hash(*number)?.as_ref() == Some(hash) {
+					latest_checkpoint = Some((hash, number, *set_id));
+				}
+			}
+		}
+
+		let (checkpoint_header, set_change_blocks) = if let Some((hash, number, set_id)) =
+			latest_checkpoint
+		{
+			let header = blockchain.header(*hash)?.ok_or(Error::MissingData)?;
+			let expected_set_id = if find_scheduled_change::<Block>(&header).is_some() {
+				set_id.checked_add(1).ok_or(Error::MissingData)?
+			} else {
+				set_id
+			};
+			let changes = set_changes
+				.contiguous_changes_after(expected_set_id, *number)
+				.ok_or(Error::MissingData)?;
+			(Some(header), changes)
+		} else {
+			let changes = set_changes.iter_from(begin_number).ok_or(Error::MissingData)?.collect();
+			(None, changes)
+		};
+
 		let mut proofs = Vec::new();
 		let mut proofs_encoded_len = 0;
-		let mut proof_limit_reached = false;
+		let mut proof_limit_reached = if let Some(header) = checkpoint_header {
+			!Self::push_fragment(blockchain, header, &mut proofs, &mut proofs_encoded_len)?
+		} else {
+			false
+		};
 
-		let set_change_blocks = hard_forks.warp_sync_change_blocks(
-			begin_number,
-			finalized_number,
-			set_changes,
-			|hash, number| Ok(blockchain.hash(number)?.as_ref() == Some(hash)),
-		)?;
-
-		for last_block in set_change_blocks {
+		for (_, last_block) in set_change_blocks {
+			if proof_limit_reached {
+				break
+			}
 			let hash = match blockchain.block_hash_from_id(&BlockId::Number(*last_block))? {
 				Some(hash) => hash,
 				None => {
@@ -142,8 +207,9 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 				},
 			};
 
-			// the last block in a set is the one that triggers a change to the next set,
-			// therefore the block must have a digest that signals the authority set change
+			// Recorded changes must contain the runtime signal that hands authority to the next
+			// set. Configured hard-fork checkpoints are emitted separately above and need no such
+			// signal.
 			if find_scheduled_change::<Block>(&header).is_none() {
 				// if it doesn't contain a signal for standard change then the set must have changed
 				// through a forced changed, in which case we stop collecting proofs as the chain of
@@ -151,26 +217,10 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 				break
 			}
 
-			let justification = blockchain
-				.justifications(header.hash())?
-				.and_then(|just| just.into_justification(GRANDPA_ENGINE_ID))
-				.ok_or_else(|| Error::MissingData)?;
-
-			let justification = GrandpaJustification::<Block>::decode_all(&mut &justification[..])?;
-
-			let proof = WarpSyncFragment { header: header.clone(), justification };
-			let proof_size = proof.encoded_size();
-
-			// Check for the limit. We remove some bytes from the maximum size, because we're only
-			// counting the size of the `WarpSyncFragment`s. The extra margin is here to leave
-			// room for rest of the data (the size of the `Vec` and the boolean).
-			if proofs_encoded_len + proof_size >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+			if !Self::push_fragment(blockchain, header, &mut proofs, &mut proofs_encoded_len)? {
 				proof_limit_reached = true;
 				break
 			}
-
-			proofs_encoded_len += proof_size;
-			proofs.push(proof);
 		}
 
 		let is_finished = if proof_limit_reached {
@@ -233,12 +283,18 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 			let hash = proof.header.hash();
 			let number = *proof.header.number();
 
-			if let Some((set_id, list)) = hard_forks.get_hard_forked_authorities(&(hash, number)) {
+			let is_checkpoint = if let Some((set_id, list)) =
+				hard_forks.get_hard_forked_authorities(&(hash, number))
+			{
 				current_set_id = set_id;
 				current_authorities = list.clone();
+				true
 			} else if let Some(initial_set_id) = hard_forks.get_new_initial_set_id() {
 				current_set_id += initial_set_id;
-			}
+				false
+			} else {
+				false
+			};
 			{
 				proof
 					.justification
@@ -254,7 +310,9 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 				if let Some(scheduled_change) = find_scheduled_change::<Block>(&proof.header) {
 					current_authorities = scheduled_change.next_authorities;
 					current_set_id += 1;
-				} else if fragment_num != self.proofs.len() - 1 || !self.is_finished {
+				} else if !is_checkpoint &&
+					(fragment_num != self.proofs.len() - 1 || !self.is_finished)
+				{
 					// Only the last fragment of the last proof message is allowed to be missing the
 					// authority set change.
 					return Err(Error::InvalidProof(
@@ -326,50 +384,13 @@ impl<Block: BlockT> HardForks<Block> {
 		}
 	}
 
-	/// Return the authority-change blocks to include in a warp proof. Hard-fork blocks are trusted
-	/// checkpoints: they replace older history that cannot form a valid proof, while normal
-	/// recorded changes after the last checkpoint are retained.
-	fn warp_sync_change_blocks<'a>(
-		&'a self,
-		begin: NumberFor<Block>,
-		finalized: NumberFor<Block>,
-		set_changes: &'a AuthoritySetChanges<NumberFor<Block>>,
-		mut is_canonical: impl FnMut(&Block::Hash, NumberFor<Block>) -> Result<bool, Error>,
-	) -> Result<Vec<&'a NumberFor<Block>>, Error> {
-		let HardForks::AuthoritySetHardForks { hard_forks } = self else {
-			return set_changes
-				.iter_from(begin)
-				.map(|changes| changes.map(|(_, block)| block).collect())
-				.ok_or(Error::MissingData);
-		};
-
-		let mut checkpoints = Vec::new();
-		for ((hash, number), (set_id, _)) in hard_forks {
-			if *number <= finalized && is_canonical(hash, *number)? {
-				checkpoints.push((number, *set_id));
-			}
+	fn authority_set_checkpoints(
+		&self,
+	) -> Option<&HashMap<(Block::Hash, NumberFor<Block>), (SetId, AuthorityList)>> {
+		match self {
+			Self::AuthoritySetHardForks { hard_forks } => Some(hard_forks),
+			Self::ReinitializeSetId { .. } => None,
 		}
-		checkpoints.sort_unstable_by_key(|(number, _)| *number);
-
-		let Some((last_checkpoint, last_checkpoint_set_id)) = checkpoints.last().copied() else {
-			return set_changes
-				.iter_from(begin)
-				.map(|changes| changes.map(|(_, block)| block).collect())
-				.ok_or(Error::MissingData);
-		};
-
-		let mut blocks = checkpoints
-			.into_iter()
-			.map(|(block, _)| block)
-			.filter(|checkpoint| **checkpoint > begin)
-			.collect::<Vec<_>>();
-		let suffix_begin = if begin > *last_checkpoint { begin } else { *last_checkpoint };
-		blocks.extend(
-			set_changes
-				.iter_after_known(last_checkpoint_set_id, suffix_begin)
-				.map(|(_, block)| block),
-		);
-		Ok(blocks)
 	}
 }
 
@@ -440,24 +461,83 @@ where
 
 #[cfg(test)]
 mod tests {
-	use super::{HardForks, WarpSyncProof};
-	use crate::{AuthoritySetChanges, AuthoritySetHardFork, GrandpaJustification};
+	use super::{Error, HardForks, WarpSyncProof};
+	use crate::{
+		find_scheduled_change, AuthoritySetChanges, AuthoritySetHardFork, GrandpaJustification,
+	};
 	use codec::Encode;
 	use rand::prelude::*;
 	use sc_block_builder::BlockBuilderBuilder;
 	use sp_blockchain::HeaderBackend;
 	use sp_consensus::BlockOrigin;
-	use sp_consensus_grandpa::GRANDPA_ENGINE_ID;
+	use sp_consensus_grandpa::{AuthorityList, SetId, GRANDPA_ENGINE_ID};
 	use sp_keyring::Ed25519Keyring;
-	use sp_runtime::traits::Header as _;
+	use sp_runtime::traits::{Block as BlockT, Header as _};
 	use std::sync::Arc;
 	use substrate_test_runtime_client::{
-		BlockBuilderExt, ClientBlockImportExt, ClientExt, DefaultTestClientBuilderExt,
-		TestClientBuilder, TestClientBuilderExt,
+		runtime::Block, Backend as TestBackend, BlockBuilderExt, ClientBlockImportExt, ClientExt,
+		DefaultTestClientBuilderExt, TestClientBuilder, TestClientBuilderExt,
 	};
 
-	#[test]
-	fn warp_sync_proof_generate_verify() {
+	type BlockHash = <Block as BlockT>::Hash;
+
+	struct TestCheckpoint {
+		set_id: SetId,
+		block: (BlockHash, u64),
+		authorities: AuthorityList,
+	}
+
+	impl TestCheckpoint {
+		fn hard_fork(&self) -> AuthoritySetHardFork<Block> {
+			AuthoritySetHardFork {
+				set_id: self.set_id,
+				block: self.block,
+				authorities: self.authorities.clone(),
+				last_finalized: None,
+			}
+		}
+	}
+
+	struct TestChain {
+		backend: Arc<TestBackend>,
+		genesis_hash: BlockHash,
+		genesis_authorities: AuthorityList,
+		expected_set_id: SetId,
+		expected_authorities: AuthorityList,
+		change_records: Vec<(SetId, u64)>,
+		scheduled_checkpoint: TestCheckpoint,
+		offchain_checkpoint: TestCheckpoint,
+	}
+
+	impl TestChain {
+		fn authority_set_changes(&self) -> AuthoritySetChanges<u64> {
+			AuthoritySetChanges::from(self.change_records.clone())
+		}
+
+		fn incomplete_authority_set_changes(&self) -> AuthoritySetChanges<u64> {
+			// Model a node that warp-synced to the checkpoint and therefore has no historical
+			// prefix, while retaining the bad lower-set record seen on the affected chain.
+			let mut changes = self
+				.change_records
+				.iter()
+				.cloned()
+				.filter(|(set_id, _)| *set_id >= self.offchain_checkpoint.set_id)
+				.collect::<Vec<_>>();
+			changes.push((0, self.offchain_checkpoint.block.1));
+			changes.sort_unstable_by_key(|(_, block)| *block);
+			AuthoritySetChanges::from(changes)
+		}
+
+		fn verify(
+			&self,
+			proof: &WarpSyncProof<Block>,
+			hard_forks: &HardForks<Block>,
+		) -> (SetId, AuthorityList) {
+			proof.verify(0, self.genesis_authorities.clone(), hard_forks).unwrap()
+		}
+	}
+
+	fn test_chain() -> TestChain {
 		let mut rng = rand::rngs::StdRng::from_seed([0; 32]);
 		let builder = TestClientBuilder::new();
 		let backend = builder.backend();
@@ -469,7 +549,8 @@ mod tests {
 		let mut current_authorities = vec![Ed25519Keyring::Alice];
 		let mut current_set_id = 0;
 		let mut authority_set_changes = Vec::new();
-		let mut hard_fork = None;
+		let mut scheduled_checkpoint = None;
+		let mut offchain_checkpoint = None;
 
 		for n in 1..=100 {
 			let mut builder = BlockBuilderBuilder::new(&*client)
@@ -510,9 +591,9 @@ mod tests {
 
 			futures::executor::block_on(client.import(BlockOrigin::Own, block)).unwrap();
 
-			if let Some(new_authorities) = new_authorities {
-				// generate a justification for this block, finalize it and note the authority set
-				// change
+			if new_authorities.is_some() || n == 55 {
+				// Generate a justification for every recorded change and for a hard-fork checkpoint
+				// that deliberately has no runtime change digest.
 				let (target_hash, target_number) = {
 					let info = client.info();
 					(info.best_hash, info.best_number)
@@ -540,21 +621,32 @@ mod tests {
 				let justification = GrandpaJustification::from_commit(&client, 42, commit).unwrap();
 
 				if n == 50 {
-					hard_fork = Some(AuthoritySetHardFork {
+					scheduled_checkpoint = Some(TestCheckpoint {
 						set_id: current_set_id,
 						block: (target_hash, target_number),
 						authorities: current_authorities
 							.iter()
 							.map(|keyring| (keyring.public().into(), 1))
 							.collect(),
-						last_finalized: None,
+					});
+				}
+				if n == 55 {
+					offchain_checkpoint = Some(TestCheckpoint {
+						set_id: current_set_id,
+						block: (target_hash, target_number),
+						authorities: current_authorities
+							.iter()
+							.map(|keyring| (keyring.public().into(), 1))
+							.collect(),
 					});
 				}
 
 				client
 					.finalize_block(target_hash, Some((GRANDPA_ENGINE_ID, justification.encode())))
 					.unwrap();
+			}
 
+			if let Some(new_authorities) = new_authorities {
 				authority_set_changes.push((current_set_id, n));
 
 				current_set_id += 1;
@@ -562,24 +654,45 @@ mod tests {
 			}
 		}
 
-		let authority_set_change_records = authority_set_changes;
-		let authority_set_changes = AuthoritySetChanges::from(authority_set_change_records.clone());
-
-		// generate a warp sync proof
 		let genesis_hash = client.hash(0).unwrap().unwrap();
+		let expected_authorities =
+			current_authorities.iter().map(|keyring| (keyring.public().into(), 1)).collect();
+
+		TestChain {
+			backend,
+			genesis_hash,
+			genesis_authorities,
+			expected_set_id: current_set_id,
+			expected_authorities,
+			change_records: authority_set_changes,
+			scheduled_checkpoint: scheduled_checkpoint
+				.expect("block 50 is an authority-set transition"),
+			offchain_checkpoint: offchain_checkpoint
+				.expect("block 55 is a justified off-chain checkpoint"),
+		}
+	}
+
+	#[test]
+	fn warp_sync_proof_generate_verify() {
+		let chain = test_chain();
+		let authority_set_changes = chain.authority_set_changes();
 
 		let hard_forks = HardForks::new_hard_forked_authorities(vec![]);
-		let warp_sync_proof =
-			WarpSyncProof::generate(&*backend, genesis_hash, &authority_set_changes, &hard_forks)
-				.unwrap();
+		let warp_sync_proof = WarpSyncProof::generate(
+			&*chain.backend,
+			chain.genesis_hash,
+			&authority_set_changes,
+			&hard_forks,
+		)
+		.unwrap();
 		let legacy_proof = warp_sync_proof.encode();
 
 		// Reinitializing the starting set ID is Subtensor mainnet's existing mode. Supplying that
 		// mode must not alter which proof fragments the server generates.
 		let reinitialized_set_id = HardForks::new_initial_set_id(3);
 		let reinitialized_proof = WarpSyncProof::generate(
-			&*backend,
-			genesis_hash,
+			&*chain.backend,
+			chain.genesis_hash,
 			&authority_set_changes,
 			&reinitialized_set_id,
 		)
@@ -587,21 +700,18 @@ mod tests {
 		assert_eq!(reinitialized_proof.encode(), legacy_proof);
 
 		// verifying the proof should yield the last set id and authorities
-		let (new_set_id, new_authorities) =
-			warp_sync_proof.verify(0, genesis_authorities.clone(), &hard_forks).unwrap();
+		let (new_set_id, new_authorities) = chain.verify(&warp_sync_proof, &hard_forks);
+		assert_eq!(new_set_id, chain.expected_set_id);
+		assert_eq!(new_authorities, chain.expected_authorities);
+	}
 
-		let expected_authorities = current_authorities
-			.iter()
-			.map(|keyring| (keyring.public().into(), 1))
-			.collect::<Vec<_>>();
-
-		assert_eq!(new_set_id, current_set_id);
-		assert_eq!(new_authorities, expected_authorities);
-
+	#[test]
+	fn warp_sync_uses_scheduled_checkpoint_with_incomplete_history() {
+		let chain = test_chain();
 		// A trusted checkpoint replaces earlier authority-set history during both proof generation
 		// and verification. This allows a chain to skip historical transitions that cannot produce
 		// a valid warp fragment without changing the proof's wire format.
-		let hard_fork = hard_fork.expect("block 50 is an authority-set transition");
+		let hard_fork = chain.scheduled_checkpoint.hard_fork();
 		let noncanonical_hard_fork = AuthoritySetHardFork {
 			set_id: 99,
 			block: (Default::default(), hard_fork.block.1),
@@ -619,21 +729,11 @@ mod tests {
 			noncanonical_hard_fork,
 			future_hard_fork,
 		]);
-		let poisoned_authority_set_changes = AuthoritySetChanges::from({
-			// Model a node that warp-synced to the checkpoint and therefore has no set-0 prefix.
-			let mut changes = authority_set_change_records
-				.into_iter()
-				.filter(|(set_id, _)| *set_id >= 5)
-				.collect::<Vec<_>>();
-			// Also model the bad lower-set-id record present in the affected chain database.
-			changes.push((0, 55));
-			changes.sort_unstable_by_key(|(_, block)| *block);
-			changes
-		});
+		let authority_set_changes = chain.incomplete_authority_set_changes();
 		let warp_sync_proof = WarpSyncProof::generate(
-			&*backend,
-			genesis_hash,
-			&poisoned_authority_set_changes,
+			&*chain.backend,
+			chain.genesis_hash,
+			&authority_set_changes,
 			&hard_forks,
 		)
 		.unwrap();
@@ -647,9 +747,66 @@ mod tests {
 			1,
 		);
 
-		let (new_set_id, new_authorities) =
-			warp_sync_proof.verify(0, genesis_authorities, &hard_forks).unwrap();
-		assert_eq!(new_set_id, current_set_id);
-		assert_eq!(new_authorities, expected_authorities);
+		let (new_set_id, new_authorities) = chain.verify(&warp_sync_proof, &hard_forks);
+		assert_eq!(new_set_id, chain.expected_set_id);
+		assert_eq!(new_authorities, chain.expected_authorities);
+	}
+
+	#[test]
+	fn warp_sync_uses_latest_checkpoint_without_change_digest() {
+		let chain = test_chain();
+		// A real hard-fork checkpoint is defined off-chain and therefore does not need a runtime
+		// scheduled-change digest. Only the latest canonical checkpoint is needed: the verifier can
+		// switch directly to its configured authorities before verifying later fragments.
+		let hard_forks = HardForks::new_hard_forked_authorities(vec![
+			chain.scheduled_checkpoint.hard_fork(),
+			chain.offchain_checkpoint.hard_fork(),
+		]);
+		let authority_set_changes = chain.incomplete_authority_set_changes();
+		let warp_sync_proof = WarpSyncProof::generate(
+			&*chain.backend,
+			chain.genesis_hash,
+			&authority_set_changes,
+			&hard_forks,
+		)
+		.unwrap();
+		assert_eq!(*warp_sync_proof.proofs[0].header.number(), 55);
+		assert!(find_scheduled_change::<Block>(&warp_sync_proof.proofs[0].header).is_none());
+		assert!(
+			warp_sync_proof
+				.proofs
+				.last()
+				.expect("proof contains the checkpoint")
+				.header
+				.number() > &55,
+		);
+		assert!(!warp_sync_proof.proofs.iter().any(|proof| *proof.header.number() == 50));
+
+		let (new_set_id, new_authorities) = chain.verify(&warp_sync_proof, &hard_forks);
+		assert_eq!(new_set_id, chain.expected_set_id);
+		assert_eq!(new_authorities, chain.expected_authorities);
+	}
+
+	#[test]
+	fn warp_sync_rejects_gapped_checkpoint_suffix() {
+		let chain = test_chain();
+		// A checkpoint can replace missing history before it, but not missing authority sets after
+		// it. Unit tests on `AuthoritySetChanges` cover both leading and internal gaps; keep one
+		// end-to-end assertion here to prove the generator maps that condition to `MissingData`.
+		let expected_first_set = chain.offchain_checkpoint.set_id;
+		let changes = AuthoritySetChanges::from(
+			chain
+				.change_records
+				.iter()
+				.cloned()
+				.filter(|(set_id, _)| *set_id >= expected_first_set + 2)
+				.collect::<Vec<_>>(),
+		);
+		let hard_forks =
+			HardForks::new_hard_forked_authorities(vec![chain.offchain_checkpoint.hard_fork()]);
+		assert!(matches!(
+			WarpSyncProof::generate(&*chain.backend, chain.genesis_hash, &changes, &hard_forks,),
+			Err(Error::MissingData),
+		));
 	}
 }


### PR DESCRIPTION
## Summary

This changes GRANDPA warp-proof generation so configured, finalized `AuthoritySetHardFork` entries can serve as trusted checkpoints. A proof can begin again from a checkpoint and then include the ordinary authority-set transitions recorded after it.

The proof wire format is unchanged. This only changes which existing `WarpSyncFragment`s a provider selects and serves.

## Why testnet warp sync currently stalls

The affected testnet history contains GRANDPA authority transitions that cannot be replayed as a continuous proof from set 0. In particular, a historical delayed transition does not have the stored justification needed to construct a normal warp-sync fragment. Nodes that have already warp-synced may also retain authority-change history whose first available record has a nonzero set ID, plus an obsolete lower-set record after the usable checkpoint.

Before this change, `WarpSyncProof::generate` always called `AuthoritySetChanges::iter_from(begin)`. That API deliberately rejects an incomplete historical prefix: if the first retained record is not set 0, it returns `None`, which becomes `Error::MissingData`. It also has no knowledge of configured GRANDPA hard forks. Consequently, a testnet proof provider cannot bridge the unprovable historical transition even though both sides are configured with a later trusted authority-set checkpoint. A fresh node remains in the `Downloading warp proofs` phase because it cannot obtain a complete proof chain from its peers.

## Why the change is needed in the SDK

Subtensor owns the chain-specific checkpoint hashes, set IDs, and authority lists, and supplies them through the existing `HardForks` configuration. The generic proof-selection logic, however, lives inside `sc-consensus-grandpa` and has private access to the backend, finalized chain, stored authority-set changes, proof-size limits, and `WarpSyncFragment` construction.

Subtensor can configure a checkpoint, but it cannot make the SDK generator use that checkpoint without duplicating GRANDPA's internal proof-generation implementation. Teaching the SDK's existing generator how to consume its existing hard-fork configuration keeps chain-specific data out of Polkadot SDK while preserving one implementation of the protocol.

## Implementation

- Pass the provider's `HardForks` configuration into `WarpSyncProof::generate`.
- Select only configured checkpoints that are finalized and whose exact `(hash, number)` is canonical in the provider's finalized chain.
- Emit canonical checkpoints after the request's starting block, ordered by height.
- After the last usable checkpoint, append recorded authority transitions whose set ID and block number are both later than the trusted checkpoint.
- Permit this post-checkpoint suffix to have an incomplete pre-checkpoint history, because the checkpoint supplies the missing authority-set trust anchor.
- Fall back to the existing `iter_from` behavior when there is no usable finalized checkpoint.

Canonical-hash filtering is important because hard forks are keyed by both hash and height: alternate-fork entries at the same height must not influence proof generation. Verification remains fail-closed and continues to validate the exact checkpoint hash, GRANDPA justification, authority list, and subsequent scheduled transitions.

## Compatibility and mainnet safety

- No SCALE type or network wire-format change.
- No runtime or on-chain consensus-rule change; this is node-side warp-proof generation.
- Empty hard-fork maps retain the previous generator behavior.
- `HardForks::new_initial_set_id`, which is the existing Subtensor mainnet mode, retains the previous generator path. The regression test requires its generated proof bytes to be identical to the legacy path.
- Chain-specific testnet checkpoints remain in Subtensor and are enabled there only for the exact testnet genesis hash.

## Verification

- `SKIP_WASM_BUILD=1 cargo clippy -p sc-consensus-grandpa --all-targets -- -D warnings`
- `SKIP_WASM_BUILD=1 cargo test -p sc-consensus-grandpa warp_sync_proof_generate_verify --lib`
- Combined Subtensor build and all-target Clippy against this SDK revision.
- Live testnet exercise: a fresh patched client requested a proof from a patched archive provider, verified through GRANDPA set ID 4, advanced past `Downloading warp proofs`, completed state sync, and caught up to the testnet head.

The regression coverage includes:

- an incomplete history beginning at a nonzero set ID;
- an obsolete lower-set record after the checkpoint;
- later valid authority transitions;
- an unfinalized future checkpoint, which must be ignored;
- a noncanonical checkpoint at the same height, which must be ignored;
- byte-identical proof generation for the mainnet-style initial-set-ID mode.

## Rollout order

1. Merge this SDK PR into `polkadot-stable2506-2-otf-patches`.
2. Update Subtensor to the resulting merged SDK revision and merge the dependent Subtensor PR. Avoid pinning the production Subtensor branch to an unmerged feature-head commit.
3. Deploy the updated Subtensor binary to testnet archive/RPC nodes that serve warp proofs.
4. Roll out the updated binary to fresh or syncing testnet clients after providers are available.

The SDK merge alone changes no deployed network behavior. Provider-first deployment prevents updated clients from depending on peers that still use the old generator. Mainnet does not receive the testnet checkpoint configuration and continues using its existing initial-set-ID path.
