### PR TITLE
fix(network-sync): handle empty block request ranges

### DIFF
--- a/prdoc/pr_12017.prdoc
+++ b/prdoc/pr_12017.prdoc
@@ -1,0 +1,8 @@
+title: Improve the sync
+doc:
+- audience: Node Dev
+  description: |-
+    We should not panic and handle it more gracefully.
+crates:
+- name: sc-network-sync
+  bump: patch

--- a/substrate/client/network/sync/src/blocks.rs
+++ b/substrate/client/network/sync/src/blocks.rs
@@ -20,6 +20,7 @@ use crate::LOG_TARGET;
 use log::trace;
 use sc_network_common::sync::message;
 use sc_network_types::PeerId;
+use sp_arithmetic::traits::Saturating;
 use sp_runtime::traits::{Block as BlockT, NumberFor, One};
 use std::{
 	cmp,
@@ -166,7 +167,8 @@ impl<B: BlockT> BlockCollection<B> {
 			trace!(target: LOG_TARGET, "Out of range for peer {} ({} vs {})", who, range.start, peer_best);
 			return None
 		}
-		range.end = cmp::min(peer_best + One::one(), range.end);
+
+		range.end = cmp::min(peer_best.saturating_add(One::one()), range.end);
 
 		if self
 			.blocks
@@ -178,6 +180,19 @@ impl<B: BlockT> BlockCollection<B> {
 			return None
 		}
 
+		if range.end <= range.start {
+			debug_assert!(
+				false,
+				"Empty range {:?}, count={}, peer_best={}, common={}, blocks={:?}",
+				range, count, peer_best, common, self.blocks
+			);
+			trace!(
+				target: LOG_TARGET,
+				"Empty range for peer {who}: {range:?}, count={count}, peer_best={peer_best}, common={common}",
+			);
+			return None;
+		}
+
 		self.peer_requests.insert(who, range.start);
 		self.blocks.insert(
 			range.start,
@@ -186,12 +201,7 @@ impl<B: BlockT> BlockCollection<B> {
 				downloading: downloading + 1,
 			},
 		);
-		if range.end <= range.start {
-			panic!(
-				"Empty range {:?}, count={}, peer_best={}, common={}, blocks={:?}",
-				range, count, peer_best, common, self.blocks
-			);
-		}
+
 		Some(range)
 	}
 
@@ -296,6 +306,14 @@ mod test {
 		assert!(!is_empty(&bc));
 		bc.clear();
 		assert!(is_empty(&bc));
+	}
+
+	#[test]
+	fn peer_advertising_max_block_number_does_not_panic() {
+		let mut bc: BlockCollection<Block> = BlockCollection::new();
+		let peer = PeerId::random();
+
+		assert_eq!(bc.needed_blocks(peer, 5, u64::MAX, 0, 1, 200), Some(1..6));
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes a remotely triggerable network-sync panic caused by overflowing peer_best + 1.

- Uses saturating addition for the advertised peer height.
- Handles empty block ranges without panicking in production.
- Adds a regression test for a peer advertising the maximum block number.

Backport of paritytech/polkadot-sdk#12017.